### PR TITLE
Fix bounds check in base

### DIFF
--- a/bootstring/src/main/scala/cats/bootstring/Base.scala
+++ b/bootstring/src/main/scala/cats/bootstring/Base.scala
@@ -103,7 +103,7 @@ object Base {
       }
 
     override def unsafeIntToCodePointDigit(int: Int, uppercase: Boolean = false): Int =
-      if (int < lowercaseArray.size) {
+      if (int < lowercaseArray.size && int >= 0) {
         if (uppercase) {
           uppercaseArray(int)
         } else {

--- a/bootstring/src/test/scala/cats/bootstring/BaseTests.scala
+++ b/bootstring/src/test/scala/cats/bootstring/BaseTests.scala
@@ -85,4 +85,10 @@ final class BaseTests extends ScalaCheckSuite {
     assertEquals(baseValue, 36)
     assertEquals(baseValue, Base.PunycodeBase.value)
   }
+
+  test(
+    "Attempting to convert invalid int values should fail gracefully for the safe methods.") {
+    assert(Base.PunycodeBase.intToCodePointDigit(-1).isLeft)
+    assert(Base.PunycodeBase.intToCodePointDigit(Base.PunycodeBase.value).isLeft)
+  }
 }


### PR DESCRIPTION
On the JVM this would just be a caught exception, but I don't want this to trigger undefined behavior on ScalaJS.