### PR TITLE
Setup Scalafix For CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
       - name: Test
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' test
 
+      - name: Check scalafix lints
+        if: matrix.java == 'temurin@8'
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' 'scalafixAll --check'
+
       - name: Check binary compatibility
         if: matrix.java == 'temurin@8'
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' mimaReportBinaryIssues

--- a/.scalafix-base.conf
+++ b/.scalafix-base.conf
@@ -1,0 +1,22 @@
+# These are rules which are valid for all versions of Scala.  We keep
+# them in a separate file so that we can include them in our main
+# .scalafix.conf, which has Scala version specific rules.
+
+rules = [
+  DisableSyntax,
+  NoValInForComprehension
+]
+
+# DisableSyntax #
+
+DisableSyntax.noAsInstanceOf = true
+DisableSyntax.noDefaultArgs = true
+DisableSyntax.noFinalize = true
+DisableSyntax.noIsInstanceOf = true
+DisableSyntax.noReturns = true
+DisableSyntax.noThrows = false
+DisableSyntax.noUniversalEquality = true
+DisableSyntax.noValPatterns = true
+DisableSyntax.noVars = true
+DisableSyntax.noWhileLoops = true
+DisableSyntax.noXml = true

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,25 +1,8 @@
-rules = [
-  DisableSyntax,
-  ExplicitResultTypes,
-  NoValInForComprehension,
-  ProcedureSyntax,
-  RemoveUnused
-]
-
-# ExplicitResultTypes #
+include ".scalafix-base.conf"
 
 ExplicitResultTypes.memberVisibility = [Public, Protected, Private]
 
-# DisableSyntax #
-
-DisableSyntax.noAsInstanceOf = true
-DisableSyntax.noDefaultArgs = true
-DisableSyntax.noFinalize = true
-DisableSyntax.noIsInstanceOf = true
-DisableSyntax.noReturns = true
-DisableSyntax.noThrows = false
-DisableSyntax.noUniversalEquality = true
-DisableSyntax.noValPatterns = true
-DisableSyntax.noVars = true
-DisableSyntax.noWhileLoops = true
-DisableSyntax.noXml = true
+# Scala version specific rules
+rules += ExplicitResultTypes
+rules += ProcedureSyntax
+rules += RemoveUnused

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.0"
+ThisBuild / tlBaseVersion := "0.1"
 
 val Scala212                    = "2.12.17"
 val Scala213                    = "2.13.9"

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 ThisBuild / tlBaseVersion := "0.0"
 
-val Scala212 = "2.12.17"
-val Scala213 = "2.13.9"
-val Scala3   = "3.1.3"
+val Scala212                    = "2.12.17"
+val Scala213                    = "2.13.9"
+val Scala3                      = "3.1.3"
+def DefaultScalaVersion: String = Scala213
 
 val catsV            = "2.8.0"
 val disciplineMunitV = "2.0.0-M3"
@@ -10,17 +11,11 @@ val literallyV       = "1.1.0"
 val munitV           = "1.0.0-M6"
 val scalacheckV      = "1.17.0"
 
-ThisBuild / crossScalaVersions         := Seq(Scala212, Scala213, Scala3)
-ThisBuild / scalaVersion               := Scala213
-ThisBuild / scalafixScalaBinaryVersion := (LocalRootProject / scalaBinaryVersion).value
-
+ThisBuild / crossScalaVersions := Seq(Scala212, Scala213, Scala3)
+ThisBuild / scalaVersion       := Scala213
 ThisBuild / developers += tlGitHubDev("isomarcte", "David Strawn")
 ThisBuild / licenses  := List(License.MIT)
 ThisBuild / startYear := Some(2022)
-
-// TODO remove me!
-ThisBuild / tlFatalWarnings   := false
-ThisBuild / tlCiScalafixCheck := false
 
 // Utility
 
@@ -33,6 +28,31 @@ ThisBuild / wildcardImport := {
     '_'
   }
 }
+
+// Scalafix
+
+// Use the scalafix config which is valid for all versions of Scala if
+// scalaVersion is different than the default one. Otherwise, use the full
+// scalafix config, which includes Scala version specific rules.
+ThisBuild / scalafixConfig := {
+  if (scalaVersion.value != DefaultScalaVersion) {
+    Some(file(".scalafix-base.conf"))
+  } else scalafixConfig.value
+}
+ThisBuild / scalafixScalaBinaryVersion := {
+  if (scalaVersion.value != DefaultScalaVersion) {
+    // This is the default according to Scalafix, but the key
+    // `scalafixScalaBinaryVersion` isn't actually set in the Global scope, so
+    // we can't use `scalafixScalaBinaryVersion.value` here. I believe they
+    // are defaulting the the plugin code, rather than in the sbt scope,
+    // e.g. `scalafixScalaBinaryVersion.value.?.getOrElse("2.12")`
+    "2.12"
+  } else {
+    (LocalRootProject / scalaBinaryVersion).value
+  }
+}
+
+ThisBuild / ScalafixConfig / skip := tlIsScala3.value
 
 // Projects
 

--- a/build.sbt
+++ b/build.sbt
@@ -35,12 +35,12 @@ ThisBuild / wildcardImport := {
 // scalaVersion is different than the default one. Otherwise, use the full
 // scalafix config, which includes Scala version specific rules.
 ThisBuild / scalafixConfig := {
-  if (scalaVersion.value != DefaultScalaVersion) {
+  if ((LocalRootProject / scalaVersion).value != DefaultScalaVersion) {
     Some(file(".scalafix-base.conf"))
   } else scalafixConfig.value
 }
 ThisBuild / scalafixScalaBinaryVersion := {
-  if (scalaVersion.value != DefaultScalaVersion) {
+  if ((LocalRootProject / scalaVersion).value != DefaultScalaVersion) {
     // This is the default according to Scalafix, but the key
     // `scalafixScalaBinaryVersion` isn't actually set in the Global scope, so
     // we can't use `scalafixScalaBinaryVersion.value` here. I believe they

--- a/core/js-native/src/main/scala/org/typelevel/idna4s/core/CodePointPlatform.scala
+++ b/core/js-native/src/main/scala/org/typelevel/idna4s/core/CodePointPlatform.scala
@@ -21,11 +21,8 @@
 
 package org.typelevel.idna4s.core
 
-import scala.annotation.nowarn
-
 private[core] trait CodePointPlatform {
 
-  @nowarn("msg=never used")
   private[core] def nameForCodePoint(codePoint: CodePoint): Option[String] =
     None
 }

--- a/core/shared/src/main/scala-3/org/typelevel/idna4s/core/syntax/BiasSyntax.scala
+++ b/core/shared/src/main/scala-3/org/typelevel/idna4s/core/syntax/BiasSyntax.scala
@@ -21,6 +21,7 @@
 
 package org.typelevel.idna4s.core.syntax
 
+import cats.syntax.all._
 import org.typelevel.idna4s.core.bootstring._
 import scala.language.future
 import scala.quoted.*
@@ -37,20 +38,20 @@ private object BiasSyntax {
   private def biasLiteralExpr(sc: Expr[StringContext], args: Expr[Seq[Any]])(
       using q: Quotes): Expr[Bias] =
     sc.value match {
-      case Some(sc) if sc.parts.size == 1 =>
+      case Some(sc) if sc.parts.size === 1 =>
         val value: String = sc.parts.head
         Bias
           .fromString(value)
           .fold(
             e => {
-              quotes.reflect.report.throwError(e)
+              quotes.reflect.report.errorAndAbort(e)
             },
             _ => '{ Bias.unsafeFromString(${ Expr(value) }) }
           )
       case Some(_) =>
-        quotes.reflect.report.throwError("StringContext must be a single string literal")
+        quotes.reflect.report.errorAndAbort("StringContext must be a single string literal")
       case None =>
-        quotes.reflect.report.throwError("StringContext args must be statically known")
+        quotes.reflect.report.errorAndAbort("StringContext args must be statically known")
     }
 
   inline def biasLiteral(inline sc: StringContext, inline args: Any*): Bias =

--- a/core/shared/src/main/scala-3/org/typelevel/idna4s/core/syntax/CodePointSyntax.scala
+++ b/core/shared/src/main/scala-3/org/typelevel/idna4s/core/syntax/CodePointSyntax.scala
@@ -38,7 +38,7 @@ private object CodePointSyntax {
   private def codePointLiteralExpr(sc: Expr[StringContext], args: Expr[Seq[Any]])(
       using q: Quotes): Expr[CodePoint] =
     sc.value match {
-      case Some(sc) if sc.parts.size == 1 =>
+      case Some(sc) if sc.parts.size === 1 =>
         val value: String = sc.parts.head
         CodePoint
           .fromString(value)

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Base.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Base.scala
@@ -47,7 +47,7 @@ abstract class Base extends Serializable {
    * Attempt to convert a numerical value to the Unicode code point representing a digit with
    * that value in this base.
    */
-  def intToCodePointDigit(int: Int, uppercase: Boolean = false): Either[String, Int]
+  def intToCodePointDigit(int: Int, uppercase: Boolean): Either[String, Int]
 
   /**
    * Attempt to convert a Unicode code point representing a digit in this base to a numerical
@@ -56,14 +56,29 @@ abstract class Base extends Serializable {
   def codePointDigitToInt(codePoint: Int): Either[String, Int]
 
   /**
-   * As [[#intToCodePointDigit]], but throws on invalid input.
+   * As `intToCodePointDigit`, but throws on invalid input.
    */
-  def unsafeIntToCodePointDigit(int: Int, uppercase: Boolean = false): Int
+  def unsafeIntToCodePointDigit(int: Int, uppercase: Boolean): Int
 
   /**
    * As [[#codePointDigitToInt]], but throws on invalid input.
    */
   def unsafeCodePointDigitToInt(codePoint: Int): Int
+
+  // final //
+
+  /**
+   * Attempt to convert a numerical value to the lower case Unicode code point representing a
+   * digit with that value in this base.
+   */
+  final def intToCodePointDigit(int: Int): Either[String, Int] =
+    intToCodePointDigit(int, false)
+
+  /**
+   * As `intToCodePointDigit`, but throws on invalid input and yields only lower case results.
+   */
+  final def unsafeIntToCodePointDigit(int: Int): Int =
+    unsafeIntToCodePointDigit(int, false)
 
   final override def toString: String = s"Base(value = ${value})"
 }
@@ -102,7 +117,7 @@ object Base {
           s"Code point $codePoint is not valid for the given base.")
       }
 
-    override def unsafeIntToCodePointDigit(int: Int, uppercase: Boolean = false): Int =
+    override def unsafeIntToCodePointDigit(int: Int, uppercase: Boolean): Int =
       if (int < lowercaseArray.size && int >= 0) {
         if (uppercase) {
           uppercaseArray(int)
@@ -114,9 +129,7 @@ object Base {
           s"There is no digit in this base which corresponds to $int.")
       }
 
-    override def intToCodePointDigit(
-        int: Int,
-        uppercase: Boolean = false): Either[String, Int] =
+    override def intToCodePointDigit(int: Int, uppercase: Boolean): Either[String, Int] =
       Either
         .catchNonFatal(
           unsafeIntToCodePointDigit(int, uppercase)


### PR DESCRIPTION
Scalafix doesn't support certain rules for certain scala versions. Nevertheless, we'd like to enable these rules. To resolve this, we create a `.scalafix-base.conf` file that is used if the `scalaVersion.value` is not set to the default scala version for the build (2.13.x for now).

`.scalafix.conf` includes `.scalafix-base.conf` and adds in the additional rules.

In addition, this commit enables Scalafix in CI and fixes a handful of Scalafix issues.