### PR TITLE
Clean Up Delimiter

### DIFF
--- a/core/shared/src/main/scala-3/org/typelevel/idna4s/core/syntax/DelimiterSyntax.scala
+++ b/core/shared/src/main/scala-3/org/typelevel/idna4s/core/syntax/DelimiterSyntax.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.typelevel.idna4s.core.syntax
+
+import cats.syntax.all._
+import org.typelevel.idna4s.core.bootstring._
+import scala.language.future
+import scala.quoted.*
+
+private[syntax] trait DelimiterSyntax {
+  extension (inline ctx: StringContext) {
+    inline def delimiter(inline args: Any*): Delimiter =
+      DelimiterSyntax.delimiterLiteral(ctx, args)
+  }
+}
+
+private object DelimiterSyntax {
+
+  private def delimiterLiteralExpr(sc: Expr[StringContext], args: Expr[Seq[Any]])(
+      using q: Quotes): Expr[Delimiter] =
+    sc.value match {
+      case Some(sc) if sc.parts.size === 1 =>
+        val value: String = sc.parts.head
+        Delimiter
+          .fromString(value)
+          .fold(
+            e => {
+              quotes.reflect.report.errorAndAbort(e)
+            },
+            _ => '{ Delimiter.unsafeFromString(${ Expr(value) }) }
+          )
+      case Some(_) =>
+        quotes.reflect.report.errorAndAbort("StringContext must be a single string literal")
+      case None =>
+        quotes.reflect.report.errorAndAbort("StringContext args must be statically known")
+    }
+
+  inline def delimiterLiteral(inline sc: StringContext, inline args: Any*): Delimiter =
+    ${ delimiterLiteralExpr('sc, 'args) }
+}

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/CodePoint.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/CodePoint.scala
@@ -99,8 +99,8 @@ final class CodePoint private (val value: Int) extends AnyVal {
    * Unicode characters, one does not want to directly operation on partial surrogate values. If
    * you pull one of these values directly out of a `String` and you intend to be operating on
    * code points or Unicode characters, that likely means you have either indexed the `String`
-   * incorrectly, e.g. by char values not by code points or that the `String` not valid Unicode
-   * malformed. The `String` type does not validated that the component char values make up a
+   * incorrectly, e.g. by char values not by code points or that the `String` is not valid Unicode
+   * (malformed). The `String` type does not validated that the component char values make up a
    * valid Unicode character sequence, only that they are all valid code points.
    *
    * {{{

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/CodePoint.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/CodePoint.scala
@@ -99,9 +99,9 @@ final class CodePoint private (val value: Int) extends AnyVal {
    * Unicode characters, one does not want to directly operation on partial surrogate values. If
    * you pull one of these values directly out of a `String` and you intend to be operating on
    * code points or Unicode characters, that likely means you have either indexed the `String`
-   * incorrectly, e.g. by char values not by code points or that the `String` is not valid Unicode
-   * (malformed). The `String` type does not validated that the component char values make up a
-   * valid Unicode character sequence, only that they are all valid code points.
+   * incorrectly, e.g. by char values not by code points or that the `String` is not valid
+   * Unicode (malformed). The `String` type does not validated that the component char values
+   * make up a valid Unicode character sequence, only that they are all valid code points.
    *
    * {{{
    * // This does not have, and will never have,

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/CodePoint.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/CodePoint.scala
@@ -159,7 +159,7 @@ final class CodePoint private (val value: Int) extends AnyVal {
    * }}}
    *
    * @note
-   *   These code points are also sometimes referred to as "leading" surrogate code points.
+   *   These code points are also sometimes referred to as "trailing" surrogate code points.
    */
   def isLowSurrogate: Boolean =
     value >= 0xdc00 && value <= 0xdfff

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Bootstring.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Bootstring.scala
@@ -151,7 +151,7 @@ object Bootstring {
 
       // Insert the delimiter if there is at least one basic code point
       if (basicCodePointCount =!= 0) {
-        basicCodePoints.put(params.delimiter.codePoint)
+        basicCodePoints.put(params.delimiter.value)
       }
 
       nonBasicCodePoints.foldLeft(
@@ -353,7 +353,7 @@ object Bootstring {
           : (List[Int], List[Int], Int, Boolean) =
         foldLeftCodePoints(value.reverse)((List.empty[Int], List.empty[Int], 0, false)) {
           case ((Nil, nonBasic, basicCodePointLength, false), cp) =>
-            if (cp === params.delimiter.codePoint) {
+            if (cp === params.delimiter.value) {
               (Nil, nonBasic, basicCodePointLength, true)
             } else {
               (Nil, cp +: nonBasic, basicCodePointLength, false)

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Bootstring.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Bootstring.scala
@@ -151,7 +151,7 @@ object Bootstring {
 
       // Insert the delimiter if there is at least one basic code point
       if (basicCodePointCount =!= 0) {
-        basicCodePoints.put(params.delimiter.value)
+        basicCodePoints.put(params.delimiter.codePointInt)
       }
 
       nonBasicCodePoints.foldLeft(
@@ -353,7 +353,7 @@ object Bootstring {
           : (List[Int], List[Int], Int, Boolean) =
         foldLeftCodePoints(value.reverse)((List.empty[Int], List.empty[Int], 0, false)) {
           case ((Nil, nonBasic, basicCodePointLength, false), cp) =>
-            if (cp === params.delimiter.value) {
+            if (cp === params.delimiter.codePointInt) {
               (Nil, nonBasic, basicCodePointLength, true)
             } else {
               (Nil, cp +: nonBasic, basicCodePointLength, false)

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Damp.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Damp.scala
@@ -84,7 +84,12 @@ object Damp {
    * outside the valid domain for a [[Damp]] value.
    */
   def fromString(value: String): Either[String, Damp] =
-    Either.catchNonFatal(unsafeFromString(value.trim)).leftMap(_.getLocalizedMessage)
+    Either.catchNonFatal(unsafeFromString(value.trim)).leftMap {
+      case _: NumberFormatException =>
+        s"Damp values must be int32 values > 1: ${value}"
+      case otherwise =>
+        otherwise.getLocalizedMessage
+    }
 
   def unapply(value: Damp): Some[Int] =
     Some(value.value)

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Delimiter.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Delimiter.scala
@@ -21,89 +21,185 @@
 
 package org.typelevel.idna4s.core.bootstring
 
-import cats.data._
+import cats.Show
+import cats.kernel._
 import cats.syntax.all._
+import org.typelevel.idna4s.core._
 
-sealed abstract class Delimiter extends Product with Serializable {
-  def codePoint: Int
+/**
+ * An Unicode code point which acts as a delimiter between the basic code points and the
+ * non-basic code points in a Bootstring encoded `String`.
+ *
+ * From RFC-3492,
+ *
+ * "All basic code points appearing in the extended string are represented literally at the
+ * beginning of the basic string, in their original order, followed by a delimiter if (and only
+ * if) the number of basic code points is nonzero. The delimiter is a particular basic code
+ * point, which never appears in the remainder of the basic string. The decoder can therefore
+ * find the end of the literal portion (if there is one) by scanning for the last delimiter."
+ *
+ * @note
+ *   Technically, the code point can be any Unicode code point. This means that it ''might'' be
+ *   represented by more than one char in a UTF-16 `String`.
+ *
+ * @note
+ *   While RFC-3492 seems to imply that any code point can be used as a delimiter, the use of a
+ *   partial surrogate as a delimiter creates a situation of possible ambiguous parsing. For
+ *   example, if the delimiter is chosen to be a high surrogate value, and the first code point
+ *   in the non-basic set is a low surrogate value, this will create a new code point from the
+ *   combination of the pair. The result of this would make it impossible to unambiguously
+ *   detect the delimiter in the input. For this reason, [[Delimiter]] forbids the use of code
+ *   points which are part of a surrogate pair.
+ *
+ * @note
+ *   Because this type forbids code points which are high or low surrogate values, it represents
+ *   a non-continuous subset of valid Unicode code points.
+ *
+ * @see
+ *   [[https://datatracker.ietf.org/doc/html/rfc3492#section-3.1 Basic code point segregation]]
+ * @see
+ *   [[https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G2630 Unicode Surrogates]]
+ */
+final class Delimiter private (val value: Int) extends AnyVal {
 
-  final def charString: String =
-    new String(Character.toChars(codePoint))
+  /**
+   * The code point as a [[CodePoint]]. Mostly for informational purposes, such as error
+   * messages.
+   */
+  final def codePoint: CodePoint =
+    CodePoint.unsafeFromInt(value)
 
   final override def toString: String =
-    s"Delimiter(codePoint = ${codePoint}, charString = ${charString})"
+    s"Delimiter(codePoint = ${codePoint})"
 }
 
 object Delimiter {
-  final private[this] case class DelimiterImpl(override val codePoint: Int) extends Delimiter
 
+  private def apply(value: Int): Delimiter =
+    new Delimiter(value)
+
+  /**
+   * The [[Delimiter]] used by the Punycode variant of Bootstring, '-'.
+   */
   val PunycodeDelimiter: Delimiter = unsafeFromChar('-')
 
-  def fromCodePoint(codePoint: Int): Either[String, Delimiter] =
-    if (codePoint >= 0 && codePoint < 0x10ffff) {
-      Right(DelimiterImpl(codePoint))
+  /**
+   * Attempt to create a [[Delimiter]] value from a [[CodePoint]], failing if the given
+   * [[CodePoint]] is a high or low surrogate.
+   *
+   * @see
+   *   [[https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G2630 Unicode Surrogates]]
+   */
+  def fromCodePoint(codePoint: CodePoint): Either[String, Delimiter] =
+    if (codePoint.isSurrogate === false) {
+      Right(Delimiter(codePoint.value))
     } else {
-      Left(s"Not a valid Unicode code point: ${codePoint}")
+      Left(
+        s"Refusing to create RFC-3492 delimiter from code point which is a high or low surrogate value: ${codePoint}")
     }
 
+  /**
+   * Attempt to create a [[Delimiter]] value from a [[CodePoint]], throwing an exception if the
+   * given [[CodePoint]] is a high or low surrogate.
+   *
+   * @see
+   *   [[https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G2630 Unicode Surrogates]]
+   */
+  def unsafeFromCodePoint(codePoint: CodePoint): Delimiter =
+    fromCodePoint(codePoint).fold(e => throw new IllegalArgumentException(e), identity)
+
+  /**
+   * Attempt to create a [[Delimiter]] value from an arbitrary int32 value, failing if the value
+   * is not a valid Unicode code point or if the code point is a high or low surrogate value.
+   *
+   * @see
+   *   [[https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G2630 Unicode Surrogates]]
+   */
+  def fromInt(codePoint: Int): Either[String, Delimiter] =
+    CodePoint.fromInt(codePoint).flatMap(fromCodePoint)
+
+  /**
+   * Attempt to create a [[Delimiter]] value from an arbitrary int32 value, throwing an
+   * exception if the value is not a valid Unicode code point or if the code point is a high or
+   * low surrogate value.
+   *
+   * @see
+   *   [[https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G2630 Unicode Surrogates]]
+   */
+  def unsafeFromInt(codePoint: Int): Delimiter =
+    fromInt(codePoint).fold(e => throw new IllegalArgumentException(e), identity)
+
+  /**
+   * Attempt to create a [[Delimiter]] from a char value, failing if the char value is a high or
+   * low surrogate value.
+   *
+   * @see
+   *   [[https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G2630 Unicode Surrogates]]
+   */
   def fromChar(char: Char): Either[String, Delimiter] =
-    char.toInt match {
-      case value if value < Character.MIN_SURROGATE =>
-        fromCodePoint(value)
-      case _ =>
-        Left(
-          s"Char is part of a surrogate pair, but that is not a valid code point in isolation: '${char}'")
-    }
+    fromCodePoint(CodePoint.fromChar(char))
 
-  def fromSurrogatePair(high: Char, low: Char): Either[NonEmptyList[String], Delimiter] =
-    (
-      s"Character $high is not a high surrogate unicode character."
-        .leftNel[Delimiter]
-        .unlessA(Character.isHighSurrogate(high)),
-      s"Character $low is not a low surrogate unicode character."
-        .leftNel[Delimiter]
-        .unlessA(Character.isLowSurrogate(low))).parTupled.flatMap {
-      case _ => fromCodePoint(Character.toCodePoint(high, low)).leftMap(NonEmptyList.one)
-    }
-
-  def unsafeFromCodePoint(value: Int): Delimiter =
-    fromCodePoint(value).fold(
-      e => throw new IllegalArgumentException(e),
-      identity
-    )
-
+  /**
+   * Attempt to create a [[Delimiter]] from a char value, throwing an exception if the char
+   * value is a high or low surrogate value.
+   *
+   * @see
+   *   [[https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G2630 Unicode Surrogates]]
+   */
   def unsafeFromChar(char: Char): Delimiter =
-    fromChar(char).fold(
-      e => throw new IllegalArgumentException(e),
-      identity
-    )
+    fromChar(char).fold(e => throw new IllegalArgumentException(e), identity)
 
-  def unsafeFromSurrogatePair(high: Char, low: Char): Delimiter =
-    fromSurrogatePair(high, low).fold(
-      es => throw new IllegalArgumentException(es.mkString_(", ")),
-      identity
-    )
-
-  def fromString(value: String): Either[NonEmptyList[String], Delimiter] =
-    if (value.length < 3) {
-      value.toList match {
-        case high :: low :: Nil =>
-          fromSurrogatePair(high, low)
-        case char :: Nil =>
-          fromChar(char).leftMap(NonEmptyList.one)
-        case Nil =>
-          "The empty string is not a valid boostring delimiter.".leftNel
-        case _ =>
-          // Not possible
-          s"A bootstring delimiter must be a single code point, the given value is invalid: ${value}".leftNel
-      }
+  /**
+   * Attempt to create a [[Delimiter]] value from a `String`. This will fail if the `String`
+   * contains anything other than a single Unicode code point or if the code point is a high or
+   * low surrogate value.
+   *
+   * @see
+   *   [[https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G2630 Unicode Surrogates]]
+   */
+  def fromString(value: String): Either[String, Delimiter] = {
+    lazy val error: Either[String, Delimiter] =
+      Left(
+        s"A bootstring delimiter must be a single code point, the given value is invalid: ${value}")
+    if (value.length < 3 && value.length > 0) {
+      CodePoint
+        .fromInt(value.codePointAt(0))
+        .flatMap(cp =>
+          if (value.length === 1 || cp.utf16CharCount === 2) {
+            // if value.length is 2 and cp.utf16CharCount is 1, then we have 2
+            // code points, not 1.
+            fromCodePoint(cp)
+          } else {
+            error
+          })
     } else {
-      s"A bootstring delimiter must be a single code point, the given value is invalid: ${value}".leftNel
+      error
     }
+  }
 
+  /**
+   * Attempt to create a [[Delimiter]] value from a `String`. This will throw an exception if
+   * the `String` contains anything other than a single Unicode code point or if the code point
+   * is a high or low surrogate value.
+   */
   def unsafeFromString(value: String): Delimiter =
     fromString(value).fold(
-      es => throw new IllegalArgumentException(es.mkString_(", ")),
+      e => throw new IllegalArgumentException(e),
       identity
     )
+
+  implicit val hashAndOrderForDelimiter: Hash[Delimiter] with Order[Delimiter] =
+    new Hash[Delimiter] with Order[Delimiter] {
+      override def hash(x: Delimiter): Int =
+        x.hashCode
+
+      override def compare(x: Delimiter, y: Delimiter): Int =
+        x.value.compare(y.value)
+    }
+
+  implicit def orderingInstance: Ordering[Delimiter] =
+    hashAndOrderForDelimiter.toOrdering
+
+  implicit val showForDelimiter: Show[Delimiter] =
+    Show.fromToString
 }

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Delimiter.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Delimiter.scala
@@ -27,7 +27,7 @@ import cats.syntax.all._
 import org.typelevel.idna4s.core._
 
 /**
- * An Unicode code point which acts as a delimiter between the basic code points and the
+ * A Unicode code point which acts as a delimiter between the basic code points and the
  * non-basic code points in a Bootstring encoded `String`.
  *
  * From RFC-3492,

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Delimiter.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Delimiter.scala
@@ -78,6 +78,9 @@ object Delimiter {
   private def apply(value: Int): Delimiter =
     new Delimiter(value)
 
+  def unapply(value: Delimiter): Some[Int] =
+    Some(value.value)
+
   /**
    * The [[Delimiter]] used by the Punycode variant of Bootstring, '-'.
    */

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Delimiter.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Delimiter.scala
@@ -60,14 +60,14 @@ import org.typelevel.idna4s.core._
  * @see
  *   [[https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G2630 Unicode Surrogates]]
  */
-final class Delimiter private (val value: Int) extends AnyVal {
+final class Delimiter private (val codePointInt: Int) extends AnyVal {
 
   /**
    * The code point as a [[CodePoint]]. Mostly for informational purposes, such as error
    * messages.
    */
   final def codePoint: CodePoint =
-    CodePoint.unsafeFromInt(value)
+    CodePoint.unsafeFromInt(codePointInt)
 
   final override def toString: String =
     s"Delimiter(codePoint = ${codePoint})"
@@ -79,7 +79,7 @@ object Delimiter {
     new Delimiter(value)
 
   def unapply(value: Delimiter): Some[Int] =
-    Some(value.value)
+    Some(value.codePointInt)
 
   /**
    * The [[Delimiter]] used by the Punycode variant of Bootstring, '-'.
@@ -197,7 +197,7 @@ object Delimiter {
         x.hashCode
 
       override def compare(x: Delimiter, y: Delimiter): Int =
-        x.value.compare(y.value)
+        x.codePointInt.compare(y.codePointInt)
     }
 
   implicit def orderingInstance: Ordering[Delimiter] =

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/package.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/package.scala
@@ -65,7 +65,7 @@ package object bootstring {
       if (i >= value.remaining) {
         out
       } else {
-        if (value.get(i) === delimiter.value) {
+        if (value.get(i) === delimiter.codePointInt) {
           loop(i + 1, Some(i))
         } else {
           loop(i + 1, out)

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/package.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/package.scala
@@ -65,7 +65,7 @@ package object bootstring {
       if (i >= value.remaining) {
         out
       } else {
-        if (value.get(i) === delimiter.codePoint) {
+        if (value.get(i) === delimiter.value) {
           loop(i + 1, Some(i))
         } else {
           loop(i + 1, out)

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/syntax/BootstringSyntax.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/syntax/BootstringSyntax.scala
@@ -21,4 +21,4 @@
 
 package org.typelevel.idna4s.core.syntax
 
-trait BootstringSyntax extends BiasSyntax with DampSyntax
+trait BootstringSyntax extends BiasSyntax with DampSyntax with DelimiterSyntax

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/syntax/package.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/syntax/package.scala
@@ -26,4 +26,5 @@ package object syntax {
   object bootstring extends BootstringSyntax
   object bias extends BiasSyntax
   object codePoint extends CodePointSyntax
+  object delimiter extends DelimiterSyntax
 }

--- a/scalacheck/src/main/scala/org/typelevel/idna4s/scalacheck/ScalaCheckInstances.scala
+++ b/scalacheck/src/main/scala/org/typelevel/idna4s/scalacheck/ScalaCheckInstances.scala
@@ -188,6 +188,7 @@ private[scalacheck] trait ScalaCheckInstances extends Serializable {
   implicit final def cogenDelimiter: Cogen[Delimiter] =
     Cogen[Int].contramap(_.value)
 
+  @nowarn("msg=deprecated")
   implicit final def shrinkDelimiter: Shrink[Delimiter] =
     Shrink(value =>
       shrinkCodePoint

--- a/scalacheck/src/main/scala/org/typelevel/idna4s/scalacheck/ScalaCheckInstances.scala
+++ b/scalacheck/src/main/scala/org/typelevel/idna4s/scalacheck/ScalaCheckInstances.scala
@@ -173,7 +173,7 @@ private[scalacheck] trait ScalaCheckInstances extends Serializable {
     Cogen[Int].contramap(_.value)
 
   implicit final def chooseDelimiter: Choose[Delimiter] =
-    Choose.xmap[Int, Delimiter](Delimiter.unsafeFromInt, _.value)
+    Choose.xmap[Int, Delimiter](Delimiter.unsafeFromInt, _.codePointInt)
 
   implicit final def arbDelimiter: Arbitrary[Delimiter] =
     Arbitrary(
@@ -186,7 +186,7 @@ private[scalacheck] trait ScalaCheckInstances extends Serializable {
     )
 
   implicit final def cogenDelimiter: Cogen[Delimiter] =
-    Cogen[Int].contramap(_.value)
+    Cogen[Int].contramap(_.codePointInt)
 
   implicit final def shrinkDelimiter: Shrink[Delimiter] =
     Shrink(value =>

--- a/scalacheck/src/main/scala/org/typelevel/idna4s/scalacheck/ScalaCheckInstances.scala
+++ b/scalacheck/src/main/scala/org/typelevel/idna4s/scalacheck/ScalaCheckInstances.scala
@@ -28,6 +28,7 @@ import org.scalacheck._
 import org.typelevel.idna4s.core._
 import org.typelevel.idna4s.core.uts46.CodePointMapper._
 import org.typelevel.idna4s.core.uts46._
+import org.typelevel.idna4s.core.bootstring._
 import scala.annotation.nowarn
 
 private[scalacheck] trait ScalaCheckInstances extends Serializable {
@@ -144,4 +145,53 @@ private[scalacheck] trait ScalaCheckInstances extends Serializable {
       Gen.choose(Int.MinValue, -1),
       Gen.choose(Character.MAX_CODE_POINT + 1, Int.MaxValue)
     )
+
+  final def genInvalidSurrogatePair: Gen[(Char, Char)] = {
+    val genNotSurrogate: Gen[Char] =
+      Gen.choose(Char.MinValue, (Character.MIN_SURROGATE.toInt - 1).toChar)
+    val genNotLowSurrogate: Gen[Char] =
+      Gen.oneOf(
+        genNotSurrogate,
+        Gen.choose(Character.MIN_HIGH_SURROGATE, Character.MAX_HIGH_SURROGATE)
+      )
+    val genNotHighSurrogate: Gen[Char] =
+      Gen.oneOf(
+        genNotSurrogate,
+        Gen.choose(Character.MIN_LOW_SURROGATE, Character.MAX_LOW_SURROGATE)
+      )
+
+    genNotLowSurrogate.flatMap(notLow => genNotHighSurrogate.map(notHigh => notLow -> notHigh))
+  }
+
+  implicit final def chooseDamp: Choose[Damp] =
+    Choose.xmap[Int, Damp](Damp.unsafeFromInt, _.value)
+
+  implicit final def arbDamp: Arbitrary[Damp] =
+    Arbitrary(Gen.choose(Damp.MinValue, Damp.MaxValue))
+
+  implicit final def cogenDamp: Cogen[Damp] =
+    Cogen[Int].contramap(_.value)
+
+  implicit final def chooseDelimiter: Choose[Delimiter] =
+    Choose.xmap[Int, Delimiter](Delimiter.unsafeFromInt, _.value)
+
+  implicit final def arbDelimiter: Arbitrary[Delimiter] =
+    Arbitrary(
+      Gen
+        .oneOf(
+          Gen.choose(0, Character.MIN_SURROGATE - 1),
+          Gen.choose(Character.MAX_SURROGATE + 1, Character.MAX_CODE_POINT)
+        )
+        .map(Delimiter.unsafeFromInt)
+    )
+
+  implicit final def cogenDelimiter: Cogen[Delimiter] =
+    Cogen[Int].contramap(_.value)
+
+  implicit final def shrinkDelimiter: Shrink[Delimiter] =
+    Shrink(value =>
+      shrinkCodePoint
+        .shrink(value.codePoint)
+        .filterNot(_.isSurrogate)
+        .map(Delimiter.unsafeFromCodePoint))
 }

--- a/scalacheck/src/main/scala/org/typelevel/idna4s/scalacheck/ScalaCheckInstances.scala
+++ b/scalacheck/src/main/scala/org/typelevel/idna4s/scalacheck/ScalaCheckInstances.scala
@@ -31,6 +31,7 @@ import org.typelevel.idna4s.core.uts46._
 import org.typelevel.idna4s.core.bootstring._
 import scala.annotation.nowarn
 
+@nowarn("msg=deprecated")
 private[scalacheck] trait ScalaCheckInstances extends Serializable {
 
   implicit final def chooseCodePoint: Choose[CodePoint] =
@@ -42,7 +43,6 @@ private[scalacheck] trait ScalaCheckInstances extends Serializable {
   implicit final def cogenCodePoint: Cogen[CodePoint] =
     Cogen[Int].contramap(_.value)
 
-  @nowarn("msg=deprecated")
   implicit final def shrinkCodePoint: Shrink[CodePoint] = {
 
     // Based on ShrinkIntegral from ScalaCheck, but without negation.
@@ -188,7 +188,6 @@ private[scalacheck] trait ScalaCheckInstances extends Serializable {
   implicit final def cogenDelimiter: Cogen[Delimiter] =
     Cogen[Int].contramap(_.value)
 
-  @nowarn("msg=deprecated")
   implicit final def shrinkDelimiter: Shrink[Delimiter] =
     Shrink(value =>
       shrinkCodePoint

--- a/scalacheck/src/main/scala/org/typelevel/idna4s/scalacheck/package.scala
+++ b/scalacheck/src/main/scala/org/typelevel/idna4s/scalacheck/package.scala
@@ -22,7 +22,5 @@
 package org.typelevel.idna4s
 
 package object scalacheck {
-  object all extends ScalaCheckInstances with BootstringScalaCheckInstances
-  object core extends ScalaCheckInstances
-  object bootstring extends BootstringScalaCheckInstances
+  object all extends ScalaCheckInstances
 }

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/CodePointTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/CodePointTests.scala
@@ -119,10 +119,15 @@ final class CodePointTests extends DisciplineSuite {
   }
 
   test("Literal syntax for invalid literals should not compile") {
-    compileErrors("""codePoint"DERP"""").contains(
-      "Given value is not a valid non-negative integral value")
-    compileErrors("""codePoint"F"""").contains(
-      "Given value is not a valid non-negative integral value")
+    assert(
+      compileErrors("""codePoint"DERP"""").contains(
+        "Given value is not a valid non-negative integral value")
+    )
+
+    assert(
+      compileErrors("""codePoint"F"""").contains(
+        "Given value is not a valid non-negative integral value")
+    )
   }
 
   test("CodePoint.toString should not throw any NPEs") {

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/CodePointTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/CodePointTests.scala
@@ -120,13 +120,13 @@ final class CodePointTests extends DisciplineSuite {
 
   test("Literal syntax for invalid literals should not compile") {
     assert(
-      compileErrors("""codePoint"DERP"""").contains(
-        "Given value is not a valid non-negative integral value")
+      clue(compileErrors("""codePoint"DERP""""))
+        .contains("Given value is not a valid non-negative integral value")
     )
 
     assert(
-      compileErrors("""codePoint"F"""").contains(
-        "Given value is not a valid non-negative integral value")
+      clue(compileErrors("""codePoint"F""""))
+        .contains("Given value is not a valid non-negative integral value")
     )
   }
 

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/CodePointTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/CodePointTests.scala
@@ -139,6 +139,52 @@ final class CodePointTests extends DisciplineSuite {
     loop(0)
   }
 
+  test("CodePoint.isHighSurrogate aggress with java.lang.Character") {
+    @tailrec
+    def loop(i: Int): Unit =
+      if (i > Character.MAX_HIGH_SURROGATE) {
+        ()
+      } else {
+        assertEquals(
+          CodePoint.unsafeFromInt(i).isHighSurrogate,
+          Character.isHighSurrogate(i.toChar))
+
+        loop(i + 1)
+      }
+
+    loop(Character.MIN_HIGH_SURROGATE)
+  }
+
+  test("CodePoint.isLowSurrogate aggress with java.lang.Character") {
+    @tailrec
+    def loop(i: Int): Unit =
+      if (i > Character.MAX_LOW_SURROGATE) {
+        ()
+      } else {
+        assertEquals(
+          CodePoint.unsafeFromInt(i).isLowSurrogate,
+          Character.isLowSurrogate(i.toChar))
+
+        loop(i + 1)
+      }
+
+    loop(Character.MIN_LOW_SURROGATE)
+  }
+
+  test("CodePoint.isSurrogate aggress with java.lang.Character") {
+    @tailrec
+    def loop(i: Int): Unit =
+      if (i > Character.MAX_SURROGATE) {
+        ()
+      } else {
+        assertEquals(CodePoint.unsafeFromInt(i).isSurrogate, Character.isSurrogate(i.toChar))
+
+        loop(i + 1)
+      }
+
+    loop(Character.MIN_SURROGATE)
+  }
+
   // Laws //
 
   checkAll("Order[CodePoint]", OrderTests[CodePoint].order)

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DampTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DampTests.scala
@@ -53,13 +53,13 @@ final class DampTests extends DisciplineSuite {
 
   test("Literal syntax for invalid literals should not compile") {
     assert(
-      compileErrors("""damp"DERP"""").contains(
+      clue(compileErrors("""damp"DERP"""")).contains(
         "Damp values must be int32 values > 1: DERP"
       )
     )
 
     assert(
-      compileErrors("""damp"-1"""").contains(
+      clue(compileErrors("""damp"-1"""")).contains(
         "According to RFC-3492 damp values must be >= 2: -1"
       )
     )

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DampTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DampTests.scala
@@ -52,10 +52,17 @@ final class DampTests extends DisciplineSuite {
   }
 
   test("Literal syntax for invalid literals should not compile") {
-    compileErrors("""damp"DERP"""").contains(
-      "Given value is not a valid non-negative integral value")
-    compileErrors("""damp"F"""").contains(
-      "Given value is not a valid non-negative integral value")
+    assert(
+      compileErrors("""damp"DERP"""").contains(
+        "Damp values must be int32 values > 1: DERP"
+      )
+    )
+
+    assert(
+      compileErrors("""damp"-1"""").contains(
+        "According to RFC-3492 damp values must be >= 2: -1"
+      )
+    )
   }
 
   // Laws //

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DelimiterTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DelimiterTests.scala
@@ -141,10 +141,16 @@ final class DelimiterTests extends DisciplineSuite {
   }
 
   test("Literal syntax for invalid literals should not compile") {
-    compileErrors("""delimiter"DERP"""").contains(
-      "Given value is not a valid non-negative integral value")
-    compileErrors("""delimiter"F"""").contains(
-      "Given value is not a valid non-negative integral value")
+    assert(
+      compileErrors("""delimiter"DERP"""").contains(
+        "A bootstring delimiter must be a single code point, the given value is invalid: DERP"
+      )
+    )
+    assert(
+      compileErrors("""delimiter""""").contains(
+        "A bootstring delimiter must be a single code point, the given value is invalid:"
+      )
+    )
   }
 
   // Laws //

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DelimiterTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DelimiterTests.scala
@@ -67,7 +67,7 @@ final class DelimiterTests extends DisciplineSuite {
         loop(Character.MAX_SURROGATE + 1)
       } else {
         val d: Delimiter = Delimiter.unsafeFromInt(i)
-        assertEquals(d.value, i)
+        assertEquals(d.codePointInt, i)
 
         d.codePoint.toChars match {
           case x :: Nil =>

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DelimiterTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DelimiterTests.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.typelevel.idna4s.tests.bootstring
+
+import cats.kernel.laws.discipline._
+import cats.syntax.all._
+import munit._
+import org.scalacheck.Prop._
+import org.scalacheck._
+import org.typelevel.idna4s.core._
+import org.typelevel.idna4s.core.bootstring._
+import org.typelevel.idna4s.core.syntax.all._
+import org.typelevel.idna4s.scalacheck.all._
+import scala.annotation.tailrec
+
+final class DelimiterTests extends DisciplineSuite {
+
+  test("Delimiter.fromInt should succeed for all code points, which are not surrogate values") {
+
+    @tailrec
+    def loop(i: Int): Unit =
+      if (i > Character.MAX_CODE_POINT) {
+        ()
+      } else {
+        val cp: CodePoint = CodePoint.unsafeFromInt(i)
+
+        if (cp.isSurrogate) {
+          assert(Delimiter.fromInt(i).isLeft)
+          assert(Delimiter.fromCodePoint(cp).isLeft)
+        } else {
+          assert(Delimiter.fromInt(i).isRight)
+          assert(Delimiter.fromCodePoint(cp).isRight)
+        }
+
+        loop(i + 1)
+      }
+
+    loop(0)
+  }
+
+  test("Delimiter round trip") {
+
+    @tailrec
+    def loop(i: Int): Unit =
+      if (i > Character.MAX_CODE_POINT) {
+        ()
+      } else if (i === Character.MIN_SURROGATE) {
+        loop(Character.MAX_SURROGATE + 1)
+      } else {
+        val d: Delimiter = Delimiter.unsafeFromInt(i)
+        assertEquals(d.value, i)
+
+        d.codePoint.toChars match {
+          case x :: Nil =>
+            assertEquals(Delimiter.unsafeFromChar(x).codePoint, d.codePoint)
+          case x :: y :: Nil =>
+            assertEquals(Delimiter.unsafeFromInt(Character.toCodePoint(x, y)), d)
+          case _ =>
+            fail(s"Delimiter ${i} did not yield 1 or 2 chars.")
+        }
+
+        loop(i + 1)
+      }
+
+    loop(0)
+  }
+
+  test(
+    "Delimiter construction for chars should succeed for all chars which are not surrogates") {
+
+    @tailrec
+    def loop(i: Int): Unit =
+      if (i >= Char.MaxValue.toInt) {
+        ()
+      } else {
+        val cp: CodePoint = CodePoint.fromChar(i.toChar)
+        if (cp.isSurrogate) {
+          assert(Delimiter.fromChar(i.toChar).isLeft)
+        } else {
+          assert(Delimiter.fromChar(i.toChar).isRight)
+        }
+
+        loop(i + 1)
+      }
+
+    loop(0)
+  }
+
+  test("Delimiter.fromString should parse valid code points which are not surrogates") {
+
+    @tailrec
+    def loop(i: Int): Unit =
+      if (i > Character.MAX_CODE_POINT) {
+        ()
+      } else if (i === Character.MIN_SURROGATE) {
+        loop(Character.MAX_SURROGATE + 1)
+      } else {
+        assertEquals(
+          Delimiter.fromString(new String(Character.toChars(i))),
+          Right(Delimiter.unsafeFromInt(i)))
+
+        loop(i + 1)
+      }
+
+    loop(0)
+  }
+
+  test("Delimiter.fromString fails for non integral strings") {
+    assert(CodePoint.fromString("DERP").isLeft)
+  }
+
+  property("Delimiter.fromInt should fail for non code points")(
+    forAll(genNonCodePoint)(i => Prop(Delimiter.fromInt(i).isLeft) :| "Delimiter.fromInt fails")
+  )
+
+  test("Literal syntax for valid Delimiter should compile") {
+    assertEquals(delimiter"0", Delimiter.unsafeFromChar('0'))
+    assertEquals(delimiter"-", Delimiter.unsafeFromChar('-'))
+
+    // Multi char code point
+    assertEquals(delimiter"𐀀", Delimiter.unsafeFromCodePoint(codePoint"0x10000"))
+  }
+
+  test("Literal syntax for invalid literals should not compile") {
+    compileErrors("""delimiter"DERP"""").contains(
+      "Given value is not a valid non-negative integral value")
+    compileErrors("""delimiter"F"""").contains(
+      "Given value is not a valid non-negative integral value")
+  }
+
+  // Laws //
+
+  checkAll("Order[Delimiter]", OrderTests[Delimiter].order)
+  checkAll("Hash[Delimiter]", HashTests[Delimiter].hash)
+}


### PR DESCRIPTION
* Forbid partial surrogate values in Delimiter because of the ambiguity it creates.
* Move Bootstring ScalaCheck instances into `ScalaCheckInstances`. They build off of each other and we already had the core/uts46 instances combined.
* Add ScalaCheck instances for `Delimiter`.
* Add syntax for `Delimiter` literals.
* Add methods for noting if a `CodePoint` is a high/low surrogate value in `CodePoint`. It's a nice to have for general debugging, and we use it in `Delimiter`.
* Document `Delimiter`.
* Make `Delimiter` a value class.
* Add `codePoint` to `Delimiter` to extract out the `CodePoint` representation of the `Delimiter`.
* Generally cleanup and simplify the methods to construct a `Delimiter`.
* Add cats and stdlib typeclass instances.
* Add `Delimiter` tests and a few additional `CodePoint` tests around the new surrogate methods.