### PR TITLE
Fix Literal Tests

### DIFF
--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Damp.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Damp.scala
@@ -84,7 +84,12 @@ object Damp {
    * outside the valid domain for a [[Damp]] value.
    */
   def fromString(value: String): Either[String, Damp] =
-    Either.catchNonFatal(unsafeFromString(value.trim)).leftMap(_.getLocalizedMessage)
+    Either.catchNonFatal(unsafeFromString(value.trim)).leftMap {
+      case _: NumberFormatException =>
+        s"Damp values must be int32 values > 1: ${value}"
+      case otherwise =>
+        otherwise.getLocalizedMessage
+    }
 
   def unapply(value: Damp): Some[Int] =
     Some(value.value)

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/CodePointTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/CodePointTests.scala
@@ -119,10 +119,15 @@ final class CodePointTests extends DisciplineSuite {
   }
 
   test("Literal syntax for invalid literals should not compile") {
-    compileErrors("""codePoint"DERP"""").contains(
-      "Given value is not a valid non-negative integral value")
-    compileErrors("""codePoint"F"""").contains(
-      "Given value is not a valid non-negative integral value")
+    assert(
+      compileErrors("""codePoint"DERP"""").contains(
+        "Given value is not a valid non-negative integral value")
+    )
+
+    assert(
+      compileErrors("""codePoint"F"""").contains(
+        "Given value is not a valid non-negative integral value")
+    )
   }
 
   test("CodePoint.toString should not throw any NPEs") {

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/CodePointTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/CodePointTests.scala
@@ -120,13 +120,13 @@ final class CodePointTests extends DisciplineSuite {
 
   test("Literal syntax for invalid literals should not compile") {
     assert(
-      compileErrors("""codePoint"DERP"""").contains(
-        "Given value is not a valid non-negative integral value")
+      clue(compileErrors("""codePoint"DERP""""))
+        .contains("Given value is not a valid non-negative integral value")
     )
 
     assert(
-      compileErrors("""codePoint"F"""").contains(
-        "Given value is not a valid non-negative integral value")
+      clue(compileErrors("""codePoint"F""""))
+        .contains("Given value is not a valid non-negative integral value")
     )
   }
 

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DampTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DampTests.scala
@@ -53,13 +53,13 @@ final class DampTests extends DisciplineSuite {
 
   test("Literal syntax for invalid literals should not compile") {
     assert(
-      compileErrors("""damp"DERP"""").contains(
+      clue(compileErrors("""damp"DERP"""")).contains(
         "Damp values must be int32 values > 1: DERP"
       )
     )
 
     assert(
-      compileErrors("""damp"-1"""").contains(
+      clue(compileErrors("""damp"-1"""")).contains(
         "According to RFC-3492 damp values must be >= 2: -1"
       )
     )

--- a/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DampTests.scala
+++ b/tests/shared/src/test/scala/org/typelevel/idna4s/tests/bootstring/DampTests.scala
@@ -52,10 +52,17 @@ final class DampTests extends DisciplineSuite {
   }
 
   test("Literal syntax for invalid literals should not compile") {
-    compileErrors("""damp"DERP"""").contains(
-      "Given value is not a valid non-negative integral value")
-    compileErrors("""damp"F"""").contains(
-      "Given value is not a valid non-negative integral value")
+    assert(
+      compileErrors("""damp"DERP"""").contains(
+        "Damp values must be int32 values > 1: DERP"
+      )
+    )
+
+    assert(
+      compileErrors("""damp"-1"""").contains(
+        "According to RFC-3492 damp values must be >= 2: -1"
+      )
+    )
   }
 
   // Laws //


### PR DESCRIPTION
`compileErrors` was not being asserted.

Also make the error message for non-integral values in `Damp` better.