### PR TITLE
Cleanup Error Handling

### DIFF
--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/IDNAException.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/IDNAException.scala
@@ -1,0 +1,23 @@
+package org.typelevel.idna4s.core
+
+import cats._
+
+/**
+ * Marker trait for IDNA errors.
+ *
+ * Errors in idna4s are usually scoped to sub-domains, e.g. a class of errors for Bootstring, a
+ * class of errors for UTS-46 code point mapping, etc. In many cases we are mandated by the
+ * relevant specifications to return an error ''and'' continue processing, so we often end up in
+ * a situation where we have a partial result and more than one error.
+ *
+ * We use the [[IDNAException]] marker trait so that we can express certain errors in their
+ * domain specific representation, but still aggregate different domains together, e.g. `((a:
+ * NonEmptyList[BootStringException]).widen ++ (b: NonEmptyList[MappingException]).widen):
+ * NonEmptyList[IDNAException]`.
+ */
+trait IDNAException extends RuntimeException
+
+object IDNAException {
+  implicit val showForIDNAException: Show[IDNAException] =
+    Show.fromToString
+}

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/IDNAException.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/IDNAException.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package org.typelevel.idna4s.core
 
 import cats._

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Bootstring.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/bootstring/Bootstring.scala
@@ -29,6 +29,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
 import scala.util.control.NoStackTrace
+import scala.util.control.NonFatal
 
 object Bootstring {
 
@@ -194,7 +195,7 @@ object Bootstring {
     } catch {
       case e: BootstringException =>
         Left(e)
-      case e: Exception =>
+      case NonFatal(e) =>
         Left(
           BootstringException
             .WrappedException("Caught unhandled exception during bootstring encoding.", e))
@@ -394,10 +395,10 @@ object Bootstring {
     } catch {
       case e: BootstringException =>
         Left(e)
-      case e: Exception =>
+      case NonFatal(e) =>
         Left(
           BootstringException
-            .WrappedException("Caught unhandled exception during bootstring decodeing.", e))
+            .WrappedException("Caught unhandled exception during bootstring decoding.", e))
     }
   }
 
@@ -469,12 +470,10 @@ object Bootstring {
 
     final private[Bootstring] case class WrappedException(
         override val getMessage: String,
-        cause: Exception)
+        override val getCause: Throwable)
         extends BootstringException {
-      final override def getCause: Throwable = cause
-
       final override def toString: String =
-        s"WrappedException(cause = ${cause}, cause.getLocalizedMessage = ${cause.getLocalizedMessage})"
+        s"WrappedException(getMessage = ${getMessage}, getCause = ${getCause}, cause.getLocalizedMessage = ${getCause.getLocalizedMessage})"
     }
 
   }

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/uts46/CodePointMapper.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/uts46/CodePointMapper.scala
@@ -344,7 +344,7 @@ object CodePointMapper extends GeneratedCodePointMapper {
   /**
    * An error that is yielded when mapping an individual code point fails.
    */
-  sealed abstract class CodePointMappingException extends RuntimeException with NoStackTrace {
+  sealed abstract class CodePointMappingException extends IDNAException with NoStackTrace {
 
     /**
      * The index of the start of the Unicode code point in the input where the failure occurred.
@@ -408,7 +408,7 @@ object CodePointMapper extends GeneratedCodePointMapper {
    * An error which is yielded if attempting to map a sequence of Unicode code points with the
    * UTS-46 mapping algorithm fails.
    */
-  sealed abstract class MappingException extends RuntimeException with NoStackTrace {
+  sealed abstract class MappingException extends IDNAException with NoStackTrace {
 
     /**
      * One or more mapping [[CodePointMappingException]].

--- a/core/shared/src/test/scala/org/typelevel/idna4s/core/bootstring/PunycodeTests.scala
+++ b/core/shared/src/test/scala/org/typelevel/idna4s/core/bootstring/PunycodeTests.scala
@@ -28,9 +28,9 @@ final class PunycodeTests extends ScalaCheckSuite {
 
   test("The Punycode sample strings from RFC 3492 should encoded/decode correctly") {
     PunycodeTestStrings.foreach { (value: PunycodeTestString) =>
-      val encoded: Either[String, String] =
+      val encoded: Either[Bootstring.BootstringException, String] =
         Bootstring.encodeRaw(BootstringParams.PunycodeParams)(value.raw)
-      val decoded: Either[String, String] =
+      val decoded: Either[Bootstring.BootstringException, String] =
         Bootstring.decodeRaw(BootstringParams.PunycodeParams)(value.encoded)
 
       assertEquals(


### PR DESCRIPTION
This commit cleans up and standardizes how we are handling errors.

The goals are,

* Use `Either[String, A]` for data type constructors which have a restricted domain.
* Use something which extends `RuntimeException` for any other type of error.
* Use a marker trait `IDNAException` for all error types, so we can aggregate error types from different subdomains together, e.g. bootstring, uts-46, idna2008, etc.
* Be very specific about the error in a subdomain, but be very conservative about the types exposed for the subdomain. * For example, `BootstringException` is sealed, but no constructors are exposed.