### PR TITLE
Add Code Gen For UnicodeData.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,4 +271,4 @@ jobs:
       - name: Checkout current branch (fast)
         uses: actions/checkout@v2
 
-      - run: sbt '++${{ matrix.scala }}' 'reload plugins' 'scalafixAll --check'
+      - run: sbt '++${{ matrix.scala }}' 'reload plugins' 'scalafixAll --check' test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,8 @@ jobs:
       - name: Publish
         run: sbt '++${{ matrix.scala }}' tlRelease
 
-  scalafix-codegen:
-    name: Scalafix codegen files
+  codegen:
+    name: Codegen Test/Lint
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -272,17 +272,3 @@ jobs:
         uses: actions/checkout@v2
 
       - run: sbt '++${{ matrix.scala }}' 'reload plugins' 'scalafixAll --check' test
-
-  test-codegen:
-    name: Tests for codegen
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        scala: [2.12.17]
-        java: [temurin@11]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout current branch (fast)
-        uses: actions/checkout@v2
-
-      - run: sbt '++${{ matrix.scala }}' 'reload plugins' test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,3 +272,17 @@ jobs:
         uses: actions/checkout@v2
 
       - run: sbt '++${{ matrix.scala }}' 'reload plugins' 'scalafixAll --check' test
+
+  test-codegen:
+    name: Tests for codegen
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.12.17]
+        java: [temurin@11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (fast)
+        uses: actions/checkout@v2
+
+      - run: sbt '++${{ matrix.scala }}' 'reload plugins' test

--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     Compile / sourceGenerators ++= List(
       (Compile / sourceManaged)
         .map(
-          UTS46CodeGen.generate(_, Some(UnicodeVersion))
+          CodeGen.generate(_, UnicodeVersion)
         )
         .taskValue
     )

--- a/build.sbt
+++ b/build.sbt
@@ -63,19 +63,11 @@ ThisBuild / ScalafixConfig / skip := tlIsScala3.value
 // SBT Typelevel Github Actions
 
 ThisBuild / githubWorkflowGeneratedCI += WorkflowJob(
-  id = "scalafix-codegen",
-  name = "Scalafix codegen files",
+  id = "codegen",
+  name = "Codegen Test/Lint",
   steps = List(
     WorkflowStep.Checkout,
     WorkflowStep.Sbt(commands = List("reload plugins", "scalafixAll --check", "test"))),
-  scalas = List(Scala212)
-)
-
-ThisBuild / githubWorkflowGeneratedCI += WorkflowJob(
-  id = "test-codegen",
-  name = "Tests for codegen",
-  steps =
-    List(WorkflowStep.Checkout, WorkflowStep.Sbt(commands = List("reload plugins", "test"))),
   scalas = List(Scala212)
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,14 @@ ThisBuild / githubWorkflowGeneratedCI += WorkflowJob(
   scalas = List(Scala212)
 )
 
+ThisBuild / githubWorkflowGeneratedCI += WorkflowJob(
+  id = "test-codegen",
+  name = "Tests for codegen",
+  steps =
+    List(WorkflowStep.Checkout, WorkflowStep.Sbt(commands = List("reload plugins", "test"))),
+  scalas = List(Scala212)
+)
+
 // Projects
 
 lazy val projectName: String = "idna4s"

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ ThisBuild / githubWorkflowGeneratedCI += WorkflowJob(
   name = "Scalafix codegen files",
   steps = List(
     WorkflowStep.Checkout,
-    WorkflowStep.Sbt(commands = List("reload plugins", "scalafixAll --check"))),
+    WorkflowStep.Sbt(commands = List("reload plugins", "scalafixAll --check", "test"))),
   scalas = List(Scala212)
 )
 

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/uts46/UTS46.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/uts46/UTS46.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.typelevel.idna4s.core.uts46
+
+object UTS46 extends GeneratedUnicodeData {}

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/uts46/UnicodeDataBase.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/uts46/UnicodeDataBase.scala
@@ -58,7 +58,7 @@ private[uts46] trait UnicodeDataBase {
    * These are used to check the ContextJ rules for the UTS-46 validity criteria.
    *
    * The ContextJ rules are part of IDNA 2008, which has an initial description, but it is
-   * possible that the rules can change in the future. They current rules (still consistent with
+   * possible that the rules can change in the future. The current rules (still consistent with
    * IDNA 2008 at the time of writing) are defined by IANA.
    *
    * @see

--- a/core/shared/src/main/scala/org/typelevel/idna4s/core/uts46/UnicodeDataBase.scala
+++ b/core/shared/src/main/scala/org/typelevel/idna4s/core/uts46/UnicodeDataBase.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.typelevel.idna4s.core.uts46
+
+import scala.collection.immutable.IntMap
+import cats.collections.BitSet
+
+/**
+ * Base class used with the code generation. The generated code which implements this trait
+ * should be found in `UnicodeDataCodeGen.scala` in the `project` directory of the sbt build.
+ * The generated implementation is expected to be named `GeneratedUnicodeData`.
+ *
+ * Values in this class come from the `UnicodeData.txt` file.
+ *
+ * @see
+ *   [[https://www.unicode.org/Public/15.0.0/ucd/UnicodeData.txt]]
+ */
+private[uts46] trait UnicodeDataBase {
+
+  /**
+   * The set of Unicode code points which represent a combining mark, that is
+   * General_Category=Mark.
+   *
+   * This is needed by the validation step of UTS-46. The General_Category=Mark category is a
+   * meta-category made up of three sub categories, Spacing_Mark (Mc), Enclosing_Mark (Me), and
+   * Nonspacing_Mark (Mn). General_Category=Mark mapping to these three sets is stable for
+   * future revisions of Unicode.
+   *
+   * @see
+   *   [[https://www.unicode.org/reports/tr46/#Validity_Criteria Validity_Criteria]]
+   * @see
+   *   [[https://www.unicode.org/policies/stability_policy.html]]
+   */
+  protected def combiningMarkCodePoints: BitSet
+
+  /**
+   * The set of Unicode code points which have a canonical combining class of Virama.
+   *
+   * These are used to check the ContextJ rules for the UTS-46 validity criteria.
+   *
+   * The ContextJ rules are part of IDNA 2008, which has an initial description, but it is
+   * possible that the rules can change in the future. They current rules (still consistent with
+   * IDNA 2008 at the time of writing) are defined by IANA.
+   *
+   * @see
+   *   [[https://www.unicode.org/reports/tr46/#Validity_Criteria Validity_Criteria]]
+   * @see
+   *   [[https://www.iana.org/assignments/idna-tables-12.0.0/idna-tables-12.0.0.xhtml]]
+   */
+  protected def viramaCanonicalCombiningClassCodePoints: BitSet
+
+  /**
+   * The bidirectional category for all Unicode code points.
+   *
+   * These are used to check the bidi (bidirectional) rules for the UTS-46 validity criteria.
+   * The actual rules are defined in RFC-5893 section 2.
+   *
+   * @see
+   *   [[https://www.unicode.org/reports/tr46/#Validity_Criteria Validity_Criteria]]
+   * @see
+   *   [[https://www.rfc-editor.org/rfc/rfc5893.txt]]
+   */
+  protected def bidirectionalCategoryMap: IntMap[String]
+}

--- a/project/CodeGen.scala
+++ b/project/CodeGen.scala
@@ -1,0 +1,56 @@
+package org.typelevel.idna4s.build
+
+import cats._
+import cats.data._
+import cats.syntax.all._
+import sbt._
+
+/**
+ * Entry point for running code generation.
+ *
+ * This object provides one public method `generate` which in turn invokes all the other code
+ * generation methods. The intent is to make it simple to invoke this from `build.sbt` and
+ * ensure that all the code generation is using a consistent set of inputs, in particular the
+ * UnicodeVersion.
+ */
+object CodeGen {
+
+  /**
+   * Run all the code generation
+   *
+   * @param baseDir
+   *   the directory where the generated code files will be written, usually `(Compile /
+   *   sourceManaged)`.
+   * @param unicodeVersion
+   *   the version of Unicode to use to generate the code.
+   */
+  def generate(baseDir: File, unicodeVersion: String): Seq[File] =
+    UnicodeVersion(unicodeVersion) match {
+      case unicodeVersion =>
+        NonEmptyList
+          .of(
+            UTS46CodeGen.generate(baseDir, unicodeVersion),
+            UnicodeDataCodeGen.generate(baseDir, unicodeVersion)
+          )
+          .reduceMap(
+            _.fold(
+              e => Ior.leftNec[Throwable, NonEmptyList[File]](e),
+              f => Ior.right(NonEmptyList.one(f))
+            )
+          )
+          .fold(
+            e => throw collapseErrors(e),
+            _.toList,
+            { case (e, _) => throw collapseErrors(e) }
+          )
+    }
+
+  /**
+   * Simple method to collapse all errors we encounter during code generation into a single
+   * exception.
+   */
+  private def collapseErrors(e: NonEmptyChain[Throwable]): RuntimeException =
+    new RuntimeException(s"""Encountered ${e.size} errors during code generation: ${e
+        .map(_.getLocalizedMessage)
+        .mkString_(", ")}""")
+}

--- a/project/CodeGen.scala
+++ b/project/CodeGen.scala
@@ -25,7 +25,7 @@ object CodeGen {
    *   the version of Unicode to use to generate the code.
    */
   def generate(baseDir: File, unicodeVersion: String): Seq[File] =
-    UnicodeVersion(unicodeVersion) match {
+    UnicodeVersion.unsafeFromString(unicodeVersion) match {
       case unicodeVersion =>
         NonEmptyList
           .of(

--- a/project/CodePoint.scala
+++ b/project/CodePoint.scala
@@ -1,0 +1,49 @@
+package org.typelevel.idna4s.build
+
+import cats._
+import cats.syntax.all._
+
+/**
+ * Newtype for a Unicode code point.
+ */
+final private[build] class CodePoint private (val value: Int) extends AnyVal {
+  final override def toString: String = s"CodePoint(value = ${value})"
+}
+
+private[build] object CodePoint {
+  private def apply(value: Int): CodePoint =
+    new CodePoint(value)
+
+  def unsafeFromInt(value: Int): CodePoint =
+    fromInt(value).fold(
+      e => throw new IllegalArgumentException(e),
+      identity
+    )
+
+  def fromInt(value: Int): Either[String, CodePoint] =
+    if (value < 0 || value > Character.MAX_CODE_POINT) {
+      Left(s"Invalid code point: ${value}")
+    } else {
+      Right(apply(value))
+    }
+
+  def fromHexString(value: String): Either[String, CodePoint] = {
+    val trimmed: String = value.trim.toLowerCase
+    val integralValue: Either[Throwable, Int] =
+      if (trimmed.startsWith("0x")) {
+        Either.catchNonFatal(Integer.parseInt(trimmed.drop(2), 16))
+      } else {
+        Either.catchNonFatal(Integer.parseInt(trimmed, 16))
+      }
+    integralValue.leftMap(_.getLocalizedMessage).flatMap(fromInt)
+  }
+
+  def unsafeFromHexString(value: String): CodePoint =
+    fromHexString(value).fold(e => throw new IllegalArgumentException(e), identity)
+
+  implicit val orderInstance: Order[CodePoint] =
+    Order.by(_.value)
+
+  implicit def orderingInstance: Ordering[CodePoint] =
+    orderInstance.toOrdering
+}

--- a/project/CodePointRange.scala
+++ b/project/CodePointRange.scala
@@ -12,8 +12,6 @@ sealed abstract private[build] class CodePointRange extends Serializable {
   def lower: CodePoint
   def upper: CodePoint
 
-  // final //
-
   final def size: Int = upper.value - lower.value + 1
 
   final override def toString: String =

--- a/project/CodePointRange.scala
+++ b/project/CodePointRange.scala
@@ -1,0 +1,106 @@
+package org.typelevel.idna4s.build
+
+import cats._
+import cats.syntax.all._
+
+/**
+ * A type representing an inclusive Range of code points. This is similar to `Range`, but is
+ * used instead because `Range` has unusual equality and ordering properties and by assuming we
+ * have a non-empty, inclusive, range it was much easier to write an `Order` instance.
+ */
+sealed abstract private[build] class CodePointRange extends Serializable {
+  def lower: CodePoint
+  def upper: CodePoint
+
+  // final //
+
+  final def size: Int = upper.value - lower.value + 1
+
+  final override def toString: String =
+    if (size === 1) {
+      s"CodePointRange($lower)"
+    } else {
+      s"CodePointRange($lower, $upper)"
+    }
+}
+
+private[build] object CodePointRange {
+  final private[this] case class CodePointRangeImpl(
+      override val lower: CodePoint,
+      override val upper: CodePoint)
+      extends CodePointRange
+
+  final case class Single(value: CodePoint) extends CodePointRange {
+    override def lower: CodePoint = value
+    override def upper: CodePoint = value
+  }
+
+  object Single {
+    implicit def hashAndOrderForSingle: Hash[Single] with Order[Single] =
+      new Hash[Single] with Order[Single] {
+        override def hash(x: Single): Int =
+          hashAndOrderForCodePointRange.hash(x)
+
+        override def compare(x: Single, y: Single): Int =
+          hashAndOrderForCodePointRange.compare(x, y)
+      }
+
+    implicit def orderingInstance: Ordering[Single] =
+      hashAndOrderForSingle.toOrdering
+  }
+
+  def apply(value: CodePoint): CodePointRange =
+    Single(value)
+
+  def from(lower: CodePoint, upper: CodePoint): Either[String, CodePointRange] =
+    if (lower === upper) {
+      Right(apply(lower))
+    } else if (lower <= upper) {
+      Right(CodePointRangeImpl(lower, upper))
+    } else {
+      Left(s"Invalid CodePointRange, lower must be <= upper: [$lower, $upper]")
+    }
+
+  def unsafeFrom(lower: CodePoint, upper: CodePoint): CodePointRange =
+    from(lower, upper).fold(
+      e => throw new IllegalArgumentException(e),
+      identity
+    )
+
+  def fromInt(value: Int): Either[String, CodePointRange] =
+    CodePoint.fromInt(value).map(apply)
+
+  def fromInts(lower: Int, upper: Int): Either[String, CodePointRange] =
+    for {
+      lower  <- CodePoint.fromInt(lower)
+      upper  <- CodePoint.fromInt(upper)
+      result <- from(lower, upper)
+    } yield result
+
+  def unsafeFromInts(lower: Int, upper: Int): CodePointRange =
+    fromInts(lower, upper).fold(
+      e => throw new IllegalArgumentException(e),
+      identity
+    )
+
+  def fromHexString(value: String): Either[String, CodePointRange] =
+    CodePoint.fromHexString(value).map(apply)
+
+  def fromHexStrings(lower: String, upper: String): Either[String, CodePointRange] =
+    for {
+      lower  <- CodePoint.fromHexString(lower)
+      upper  <- CodePoint.fromHexString(upper)
+      result <- from(lower, upper)
+    } yield result
+
+  implicit val hashAndOrderForCodePointRange: Order[CodePointRange] with Hash[CodePointRange] =
+    new Order[CodePointRange] with Hash[CodePointRange] {
+      override def hash(x: CodePointRange): Int = x.hashCode
+
+      override def compare(x: CodePointRange, y: CodePointRange): Int =
+        (x.lower, x.upper).compare((y.lower, y.upper))
+    }
+
+  implicit def orderingInstance: Ordering[CodePointRange] =
+    hashAndOrderForCodePointRange.toOrdering
+}

--- a/project/UTS46CodeGen.scala
+++ b/project/UTS46CodeGen.scala
@@ -9,7 +9,6 @@ import sbt._
 import scala.annotation.tailrec
 import scala.util.Failure
 import scala.util.Success
-import scala.util.Try
 import scala.util.matching._
 import scala.collection.immutable.SortedSet
 import scala.collection.immutable.SortedMap
@@ -32,12 +31,13 @@ object UTS46CodeGen {
    * @param dir
    *   The base directory that the generated file will be in.
    */
-  def generate(dir: File, unicodeVersion: Option[String]): Seq[File] =
+  private[build] def generate(
+      dir: File,
+      unicodeVersion: UnicodeVersion): Either[Throwable, File] =
     Rows
-      .fromUnicodeURL(unicodeVersion.map(UnicodeVersion.apply))
-      .fold(
-        e => throw e,
-        rows => List(generateFromRows(rows, dir))
+      .fromUnicodeURL(unicodeVersion)
+      .map(
+        generateFromRows(_, dir)
       )
 
   /**
@@ -65,138 +65,6 @@ object UTS46CodeGen {
 
   implicit private def orphanOrderingForList[A: Order]: Ordering[List[A]] =
     Order[List[A]].toOrdering
-
-  /**
-   * A type representing an inclusive Range of code points. This is similar to `Range`, but is
-   * used instead because `Range` has unusual equality and ordering properties and by assuming
-   * we have a non-empty, inclusive, range it was much easier to write an `Order` instance.
-   */
-  sealed abstract private class CodePointRange extends Serializable {
-    def lower: CodePoint
-    def upper: CodePoint
-
-    // final //
-
-    final def size: Int = upper.value - lower.value + 1
-
-    final override def toString: String = s"CodePointRange($lower, $upper)"
-  }
-
-  private object CodePointRange {
-    final private[this] case class CodePointRangeImpl(
-        override val lower: CodePoint,
-        override val upper: CodePoint)
-        extends CodePointRange
-
-    def apply(value: CodePoint): CodePointRange =
-      CodePointRangeImpl(value, value)
-
-    def from(lower: CodePoint, upper: CodePoint): Either[String, CodePointRange] =
-      if (lower <= upper) {
-        Right(CodePointRangeImpl(lower, upper))
-      } else {
-        Left(s"Invalid CodePointRange, lower must be <= upper: [$lower, $upper]")
-      }
-
-    def fromInt(value: Int): Either[String, CodePointRange] =
-      CodePoint.fromInt(value).map(apply)
-
-    def fromInts(lower: Int, upper: Int): Either[String, CodePointRange] =
-      for {
-        lower  <- CodePoint.fromInt(lower)
-        upper  <- CodePoint.fromInt(upper)
-        result <- from(lower, upper)
-      } yield result
-
-    def unsafeFromInts(lower: Int, upper: Int): CodePointRange =
-      fromInts(lower, upper).fold(
-        e => throw new IllegalArgumentException(e),
-        identity
-      )
-
-    def fromHexString(value: String): Either[String, CodePointRange] =
-      CodePoint.fromHexString(value).map(apply)
-
-    def fromHexStrings(lower: String, upper: String): Either[String, CodePointRange] =
-      for {
-        lower  <- CodePoint.fromHexString(lower)
-        upper  <- CodePoint.fromHexString(upper)
-        result <- from(lower, upper)
-      } yield result
-
-    implicit val orderAndHashForCodePointRange
-        : Order[CodePointRange] with Hash[CodePointRange] =
-      new Order[CodePointRange] with Hash[CodePointRange] {
-        override def hash(x: CodePointRange): Int = x.hashCode
-
-        override def compare(x: CodePointRange, y: CodePointRange): Int =
-          (x.lower, x.upper).compare((y.lower, y.upper))
-      }
-
-    implicit def orderingInstance: Ordering[CodePointRange] =
-      orderAndHashForCodePointRange.toOrdering
-  }
-
-  /**
-   * Newtype for a Unicode code point.
-   */
-  final private class CodePoint private (val value: Int) extends AnyVal {
-    final override def toString: String = s"CodePoint(value = ${value})"
-  }
-
-  private object CodePoint {
-    private def apply(value: Int): CodePoint =
-      new CodePoint(value)
-
-    def unsafeFromInt(value: Int): CodePoint =
-      fromInt(value).fold(
-        e => throw new IllegalArgumentException(e),
-        identity
-      )
-
-    def fromInt(value: Int): Either[String, CodePoint] =
-      if (value < 0 || value > Character.MAX_CODE_POINT) {
-        Left(s"Invalid code point: ${value}")
-      } else {
-        Right(apply(value))
-      }
-
-    def fromHexString(value: String): Either[String, CodePoint] = {
-      val trimmed: String = value.trim.toLowerCase
-      val integralValue: Either[Throwable, Int] =
-        if (trimmed.startsWith("0x")) {
-          Either.catchNonFatal(Integer.parseInt(trimmed.drop(2), 16))
-        } else {
-          Either.catchNonFatal(Integer.parseInt(trimmed, 16))
-        }
-      integralValue.leftMap(_.getLocalizedMessage).flatMap(fromInt)
-    }
-
-    implicit val orderInstance: Order[CodePoint] =
-      Order.by(_.value)
-
-    implicit def orderingInstance: Ordering[CodePoint] =
-      orderInstance.toOrdering
-  }
-
-  /**
-   * Newtype for a Unicode version string.
-   */
-  final private case class UnicodeVersion(value: String) extends AnyVal
-
-  private object UnicodeVersion {
-    implicit val hashAndOrderForUnicodeVersion
-        : Hash[UnicodeVersion] with Order[UnicodeVersion] =
-      new Hash[UnicodeVersion] with Order[UnicodeVersion] {
-        override def hash(x: UnicodeVersion): Int = x.hashCode
-
-        override def compare(x: UnicodeVersion, y: UnicodeVersion): Int =
-          x.value.compare(y.value)
-      }
-
-    implicit def orderingInstance: Ordering[UnicodeVersion] =
-      hashAndOrderForUnicodeVersion.toOrdering
-  }
 
   /**
    * ADT for the IDNA 2008 status associated with some UTS-46 valid code points.
@@ -917,13 +785,14 @@ private[uts46] abstract class GeneratedCodePointMapper extends GeneratedCodePoin
     /**
      * Download the UTS-46 lookup table from the given URL and parse it into rows.
      */
-    def fromURL(url: String): Try[Rows] =
-      Try(new URL(url))
-        .flatMap(url => Try(IO.readLinesURL(url)))
+    def fromURL(url: String): Either[Throwable, Rows] =
+      Either
+        .catchNonFatal(new URL(url))
+        .flatMap(url => Either.catchNonFatal(IO.readLinesURL(url)))
         .flatMap(lines =>
           fromLines(lines).fold(
-            e => Failure(new RuntimeException(e)),
-            rows => Success(rows)
+            e => Left(new RuntimeException(e)),
+            rows => Right(rows)
           ))
 
     /**
@@ -934,7 +803,7 @@ private[uts46] abstract class GeneratedCodePointMapper extends GeneratedCodePoin
      *   "latest" will be used. This is the recommended usage as Unicode will post pre-release
      *   versions on their site that we probably don't want to implement a release against.
      */
-    def fromUnicodeURL(version: Option[UnicodeVersion]): Try[Rows] = {
+    def fromUnicodeURL(version: Option[UnicodeVersion]): Either[Throwable, Rows] = {
       def makeUrl(rawVersion: String): String =
         s"https://www.unicode.org/Public/idna/${rawVersion}/IdnaMappingTable.txt"
 
@@ -947,12 +816,12 @@ private[uts46] abstract class GeneratedCodePointMapper extends GeneratedCodePoin
         // Validate that if an explicit version was specified, that is what we
         // parsed.
         version.fold(
-          Success(rows): Try[Rows]
+          Right(rows): Either[Throwable, Rows]
         )(version =>
           if (rows.version === version) {
-            Success(rows)
+            Right(rows)
           } else {
-            Failure(new RuntimeException(
+            left(new RuntimeException(
               s"Expected to get the mapping table for version ${version}, but got ${rows.version}."))
           }))
     }
@@ -961,7 +830,7 @@ private[uts46] abstract class GeneratedCodePointMapper extends GeneratedCodePoin
      * Generate the mapping table code by downloading the mappings from `www.unicode.org`. The
      * "latest" version of Unicode will be used, and parsed from the file.
      */
-    def fromUnicodeURL: Try[Rows] =
+    def fromUnicodeURL: Either[Throwable, Rows] =
       fromUnicodeURL(None)
 
     /**
@@ -970,7 +839,7 @@ private[uts46] abstract class GeneratedCodePointMapper extends GeneratedCodePoin
      * @param version
      *   The version of Unicode to use to generate the mapping table code.
      */
-    def fromUnicodeURL(version: UnicodeVersion): Try[Rows] =
+    def fromUnicodeURL(version: UnicodeVersion): Either[Throwable, Rows] =
       fromUnicodeURL(Some(version))
   }
 }

--- a/project/UTS46CodeGen.scala
+++ b/project/UTS46CodeGen.scala
@@ -69,7 +69,7 @@ object UTS46CodeGen {
   /**
    * ADT for the IDNA 2008 status associated with some UTS-46 valid code points.
    */
-  sealed abstract private class IDNA2008Status extends Serializable {
+  sealed abstract private[build] class IDNA2008Status extends Serializable {
     import IDNA2008Status._
 
     final def asString: String =
@@ -79,7 +79,7 @@ object UTS46CodeGen {
       }
   }
 
-  private object IDNA2008Status {
+  private[build] object IDNA2008Status {
 
     /**
      * Valid under UTS-46, but excluded from all domain names under IDNA 2008 for all versions
@@ -697,7 +697,7 @@ import cats.data.NonEmptyList
 import cats.collections.BitSet
 
 private[uts46] abstract class GeneratedCodePointMapper0 extends CodePointMapperBase {
-  override final val unicodeVersion = ${Lit.String(version.value)}
+  override final val unicodeVersion = ${Lit.String(version.asString)}
   $mappedMultiMethod
   ..$mappedMethods
 }
@@ -762,8 +762,9 @@ private[uts46] abstract class GeneratedCodePointMapper extends GeneratedCodePoin
             Left("End of input reached without finding version string.")
           case x :: xs =>
             x match {
-              case unicodeVersionRegex(version) => Right((UnicodeVersion(version), xs))
-              case _                            => parseVersion(xs)
+              case unicodeVersionRegex(version) =>
+                UnicodeVersion.fromString(version).map((_, xs))
+              case _ => parseVersion(xs)
             }
         }
 
@@ -810,7 +811,7 @@ private[uts46] abstract class GeneratedCodePointMapper extends GeneratedCodePoin
       val url: String =
         version.fold(
           makeUrl("latest")
-        )(version => makeUrl(version.value))
+        )(version => makeUrl(version.asString))
 
       fromURL(url).flatMap(rows =>
         // Validate that if an explicit version was specified, that is what we

--- a/project/UnicodeDataCodeGen.scala
+++ b/project/UnicodeDataCodeGen.scala
@@ -26,7 +26,7 @@ import scala.util.matching._
  */
 object UnicodeDataCodeGen {
 
-  final private val BaseName          = "UnicodeData"
+  final private val BaseName                  = "UnicodeData"
   final private val BaseTypeName: String      = s"${BaseName}Base"
   final private val GeneratedTypeName: String = s"Generated${BaseName}"
 

--- a/project/UnicodeDataCodeGen.scala
+++ b/project/UnicodeDataCodeGen.scala
@@ -1,0 +1,1001 @@
+package org.typelevel.idna4s.build
+
+import cats._
+import cats.data._
+import cats.derived._
+import cats.syntax.all._
+import java.io.File
+import java.net.URL
+import sbt._
+import scala.annotation.tailrec
+import scala.collection.immutable.SortedMap
+import scala.collection.immutable.SortedSet
+import scala.meta._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import scala.util.matching._
+
+/**
+ * Code generation utilities for code which is derived from `UnicodeData.txt`.
+ *
+ * All members are private except for one, `generate`, which is package private. It is intended
+ * to be invoked from `CodeGen`. This is important because we need have to generate code from
+ * several different sources and we need to ensure that the UnicodeVersion used is always the
+ * same.
+ */
+object UnicodeDataCodeGen {
+
+  final private val BaseName          = "UnicodeData"
+  final private val BaseTypeName: String      = s"${BaseName}Base"
+  final private val GeneratedTypeName: String = s"Generated${BaseName}"
+
+  /**
+   * Generate the file for the functions, methods, and data derived from `UnicodeData.txt`.
+   */
+  private[build] def generate(
+      dir: File,
+      unicodeVersion: UnicodeVersion): Either[Throwable, File] = {
+    val outputFile: File =
+      dir / "org" / "typelevel" / "idna4s" / "core" / "uts46" / s"${GeneratedTypeName}.scala"
+
+    rowsFromUnicodeVersion(unicodeVersion)
+      .flatMap(unicodeData =>
+        rowsToUnicodeData(unicodeData).leftMap(e => new RuntimeException(e)))
+      .map { unicodeData => generatedSource(unicodeData) }
+      .flatMap(tree => Either.catchNonFatal(IO.write(outputFile, tree.syntax)))
+      .map(_ => outputFile)
+  }
+
+  /**
+   * Generate the source code for the functions, methods, and data derived from
+   * `UnicodeData.txt`.
+   */
+  private def generatedSource(unicodeData: UnicodeData): Tree = {
+    val combiningMarkCodePointsRHS: Term =
+      combiningMarkExpression(unicodeData)
+
+    source"""
+package org.typelevel.idna4s.core.uts46
+
+import cats.collections.BitSet
+import scala.collection.immutable.IntMap
+
+private[uts46] trait ${Type.Name(GeneratedTypeName)} extends ${Init(
+        Type.Name(BaseTypeName),
+        scala.meta.Name(""),
+        Nil)} {
+  override final protected lazy val combiningMarkCodePoints: BitSet = $combiningMarkCodePointsRHS
+
+  ..${bidirectionalCategoryDefs(unicodeData)}
+  ..${viramaCanonicalCombiningClassCodePointsDefs(unicodeData)}
+}"""
+  }
+
+  /**
+   * Parse the raw rows from a URL containing the `UnicodeData.txt` information.
+   */
+  private def rowsFromUrl(url: URL): Either[Throwable, Chain[UnicodeDataRow]] =
+    Either.catchNonFatal(
+      IO.readLinesURL(url).foldMap(value => Chain.one(UnicodeDataRow.unsafeFromLine(value)))
+    )
+
+  /**
+   * Parse the raw rows for a given [[UnicodeVersion]].
+   */
+  private def rowsFromUnicodeVersion(
+      unicodeVersion: UnicodeVersion): Either[Throwable, Chain[UnicodeDataRow]] =
+    Either
+      .catchNonFatal(
+        new URL(s"https://www.unicode.org/Public/${unicodeVersion.value}/ucd/UnicodeData.txt"))
+      .flatMap(
+        rowsFromUrl
+      )
+
+  /**
+   * ADT used to keep track of whether a line in `UnicodeData.txt` represents the start or end
+   * of a code point range.
+   */
+  sealed abstract private class RangeType extends Product with Serializable
+
+  private object RangeType {
+    case object Start extends RangeType
+    case object End   extends RangeType
+
+    implicit val hashAndOrderForRangeType: Hash[RangeType] with Order[RangeType] =
+      new Hash[RangeType] with Order[RangeType] {
+        override def hash(x: RangeType): Int =
+          x.hashCode
+
+        override def compare(x: RangeType, y: RangeType): Int =
+          (x, y) match {
+            case (Start, End) =>
+              -1
+            case (End, Start) =>
+              1
+            case (Start, Start) =>
+              0
+            case (End, End) =>
+              0
+          }
+      }
+
+    implicit def orderingInstance: Ordering[RangeType] =
+      hashAndOrderForRangeType.toOrdering
+  }
+
+  /**
+   * Newtype for the general category associated with a Unicode code point.
+   */
+  final private case class GeneralCategory(value: String) extends AnyVal {
+    def isCombiningMark: Boolean =
+      GeneralCategory.combiningMarkCategories.contains(value.toLowerCase)
+  }
+
+  private object GeneralCategory {
+    val combiningMarkCategories: SortedSet[String] =
+      SortedSet("Mc", "Me", "Mn").map(_.toLowerCase)
+
+    implicit val hashAndOrderForGeneralCategory
+        : Hash[GeneralCategory] with Order[GeneralCategory] =
+      new Hash[GeneralCategory] with Order[GeneralCategory] {
+        override def hash(x: GeneralCategory): Int =
+          x.hashCode
+
+        override def compare(x: GeneralCategory, y: GeneralCategory): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[GeneralCategory] =
+      hashAndOrderForGeneralCategory.toOrdering
+  }
+
+  /**
+   * Newtype for the name associated with a Unicode code point or range of code points.
+   */
+  final private case class Name(value: String) extends AnyVal
+
+  private object Name {
+    implicit val hashAndOrderForName: Hash[Name] with Order[Name] =
+      new Hash[Name] with Order[Name] {
+        override def hash(x: Name): Int =
+          x.hashCode
+
+        override def compare(x: Name, y: Name): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[Name] =
+      hashAndOrderForName.toOrdering
+  }
+
+  /**
+   * Newtype for the canonical combining class associated with a Unicode code point or range of
+   * code points.
+   */
+  final private case class CanonicalCombiningClass(value: Int) extends AnyVal {
+    def isVirama: Boolean = value === 9
+  }
+
+  private object CanonicalCombiningClass {
+
+    def fromString(value: String): Either[String, CanonicalCombiningClass] =
+      Either
+        .catchNonFatal(value.toInt)
+        .bimap(
+          _.getLocalizedMessage,
+          CanonicalCombiningClass.apply
+        )
+
+    def unsafeFromString(value: String): CanonicalCombiningClass =
+      fromString(value).fold(
+        e => throw new IllegalArgumentException(e),
+        identity
+      )
+
+    implicit val hashAndOrderForCanonicalCombiningClass
+        : Hash[CanonicalCombiningClass] with Order[CanonicalCombiningClass] =
+      new Hash[CanonicalCombiningClass] with Order[CanonicalCombiningClass] {
+        override def hash(x: CanonicalCombiningClass): Int =
+          x.hashCode
+
+        override def compare(x: CanonicalCombiningClass, y: CanonicalCombiningClass): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[CanonicalCombiningClass] =
+      hashAndOrderForCanonicalCombiningClass.toOrdering
+  }
+
+  /**
+   * Newtype for the bidirectional (bidi) category associated with a Unicode code point or range
+   * of code points.
+   */
+  final private case class BidirectionalCategory(value: String) extends AnyVal
+
+  private object BidirectionalCategory {
+    implicit val hashAndOrderForBidirectionalCategory
+        : Hash[BidirectionalCategory] with Order[BidirectionalCategory] =
+      new Hash[BidirectionalCategory] with Order[BidirectionalCategory] {
+        override def hash(x: BidirectionalCategory): Int =
+          x.hashCode
+
+        override def compare(x: BidirectionalCategory, y: BidirectionalCategory): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[BidirectionalCategory] =
+      hashAndOrderForBidirectionalCategory.toOrdering
+  }
+
+  /**
+   * Newtype for the character decomposition mapping for a Unicode code point or range of code
+   * points.
+   */
+  final private class CharacterDecompositionMapping private (val value: String) extends AnyVal
+
+  private object CharacterDecompositionMapping {
+    private def apply(value: String): CharacterDecompositionMapping =
+      new CharacterDecompositionMapping(value)
+
+    def fromString(value: String): Option[CharacterDecompositionMapping] =
+      if (value.nonEmpty) {
+        Some(CharacterDecompositionMapping(value))
+      } else {
+        None
+      }
+
+    implicit val hashAndOrderForCharacterDecompositionMapping
+        : Hash[CharacterDecompositionMapping] with Order[CharacterDecompositionMapping] =
+      new Hash[CharacterDecompositionMapping] with Order[CharacterDecompositionMapping] {
+        override def hash(x: CharacterDecompositionMapping): Int =
+          x.hashCode
+
+        override def compare(
+            x: CharacterDecompositionMapping,
+            y: CharacterDecompositionMapping): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[CharacterDecompositionMapping] =
+      hashAndOrderForCharacterDecompositionMapping.toOrdering
+  }
+
+  /**
+   * Newtype for the decimal digit value associated with a Unicode code point.
+   */
+  final private class DecimalDigitValue private (val value: Int) extends AnyVal
+
+  private object DecimalDigitValue {
+    private def apply(value: Int): DecimalDigitValue =
+      new DecimalDigitValue(value)
+
+    def unsafeFromInt(value: Int): DecimalDigitValue =
+      if (value >= 0 && value <= 9) {
+        DecimalDigitValue(value)
+      } else {
+        throw new IllegalArgumentException(
+          s"Expected decimal digit value to be [0,9], but was: ${value}")
+      }
+
+    def unsafeFromString(value: String): Option[DecimalDigitValue] =
+      if (value.nonEmpty) {
+        Some(unsafeFromInt(value.toInt))
+      } else {
+        None
+      }
+
+    implicit val hashAndOrderForDecimalDigitValue
+        : Hash[DecimalDigitValue] with Order[DecimalDigitValue] =
+      new Hash[DecimalDigitValue] with Order[DecimalDigitValue] {
+        override def hash(x: DecimalDigitValue): Int =
+          x.hashCode
+
+        override def compare(x: DecimalDigitValue, y: DecimalDigitValue): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[DecimalDigitValue] =
+      hashAndOrderForDecimalDigitValue.toOrdering
+  }
+
+  /**
+   * Newtype for the digit value associated with a Unicode code point.
+   */
+  final private class DigitValue private (val value: Int) extends AnyVal
+
+  private object DigitValue {
+    private def apply(value: Int): DigitValue =
+      new DigitValue(value)
+
+    def unsafeFromInt(value: Int): DigitValue =
+      if (value >= 0) {
+        DigitValue(value)
+      } else {
+        throw new IllegalArgumentException(
+          s"Expected digit value to be >= 0, but was: ${value}")
+      }
+
+    def unsafeFromString(value: String): Option[DigitValue] =
+      if (value.nonEmpty) {
+        Some(unsafeFromInt(value.toInt))
+      } else {
+        None
+      }
+
+    implicit val hashAndOrderForDigitValue: Hash[DigitValue] with Order[DigitValue] =
+      new Hash[DigitValue] with Order[DigitValue] {
+        override def hash(x: DigitValue): Int =
+          x.hashCode
+
+        override def compare(x: DigitValue, y: DigitValue): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[DigitValue] =
+      hashAndOrderForDigitValue.toOrdering
+  }
+
+  /**
+   * Newtype for the numeric value for a Unicode code point.
+   */
+  final private class NumericValue private (val value: String) extends AnyVal
+
+  private object NumericValue {
+    private def apply(value: String): NumericValue =
+      new NumericValue(value)
+
+    def fromString(value: String): Option[NumericValue] =
+      if (value.nonEmpty) {
+        Some(NumericValue(value))
+      } else {
+        None
+      }
+
+    implicit val hashAndOrderForNumericValue: Hash[NumericValue] with Order[NumericValue] =
+      new Hash[NumericValue] with Order[NumericValue] {
+        override def hash(x: NumericValue): Int =
+          x.hashCode
+
+        override def compare(x: NumericValue, y: NumericValue): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[NumericValue] =
+      hashAndOrderForNumericValue.toOrdering
+  }
+
+  /**
+   * Newtype for whether or not the Unicode code point represents a character which is a
+   * "mirrored" character in bidirectional text.
+   */
+  final private case class Mirrored(val value: Boolean) extends AnyVal
+
+  private object Mirrored {
+    def unsafeFromString(value: String): Mirrored =
+      if (value === "Y") {
+        Mirrored(true)
+      } else if (value === "N") {
+        Mirrored(false)
+      } else {
+        throw new IllegalArgumentException(s"Invalid value for Mirrored: ${value}")
+      }
+
+    implicit val hashAndOrderForMirrored: Hash[Mirrored] with Order[Mirrored] =
+      new Hash[Mirrored] with Order[Mirrored] {
+        override def hash(x: Mirrored): Int =
+          x.hashCode
+
+        override def compare(x: Mirrored, y: Mirrored): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[Mirrored] =
+      hashAndOrderForMirrored.toOrdering
+  }
+
+  /**
+   * Newtype for the old name as published in Unicode 1.0 or ISO 6429 names for control
+   * functions. This field is empty unless it is significantly different from the current name
+   * for the character. No longer used in code chart production.
+   */
+  final private class Unicode1Name private (val value: String) extends AnyVal
+
+  private object Unicode1Name {
+    private def apply(value: String): Unicode1Name =
+      new Unicode1Name(value)
+
+    def fromString(value: String): Option[Unicode1Name] =
+      if (value.nonEmpty) {
+        Some(Unicode1Name(value))
+      } else {
+        None
+      }
+
+    implicit val hashAndOrderForUnicode1Name: Hash[Unicode1Name] with Order[Unicode1Name] =
+      new Hash[Unicode1Name] with Order[Unicode1Name] {
+        override def hash(x: Unicode1Name): Int =
+          x.hashCode
+
+        override def compare(x: Unicode1Name, y: Unicode1Name): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[Unicode1Name] =
+      hashAndOrderForUnicode1Name.toOrdering
+  }
+
+  /**
+   * Newtype for the ISO 10646 comment field. It was used for notes that appeared in parentheses
+   * in the 10646 names list, or contained an asterisk to mark an Annex P note. As of Unicode
+   * 5.2.0, this field no longer contains any non-null values.
+   */
+  final private class ISO10646Comment private (val value: String) extends AnyVal
+
+  private object ISO10646Comment {
+    private def apply(value: String): ISO10646Comment =
+      new ISO10646Comment(value)
+
+    def fromString(value: String): Option[ISO10646Comment] =
+      if (value.nonEmpty) {
+        Some(ISO10646Comment(value))
+      } else {
+        None
+      }
+
+    implicit val hashAndOrderForISO10646Comment
+        : Hash[ISO10646Comment] with Order[ISO10646Comment] =
+      new Hash[ISO10646Comment] with Order[ISO10646Comment] {
+        override def hash(x: ISO10646Comment): Int =
+          x.hashCode
+
+        override def compare(x: ISO10646Comment, y: ISO10646Comment): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[ISO10646Comment] =
+      hashAndOrderForISO10646Comment.toOrdering
+  }
+
+  /**
+   * Newtype for the simple uppercase mapping (single character result). If a character is part
+   * of an alphabet with case distinctions, and has a simple uppercase equivalent, then the
+   * uppercase equivalent is in this field. The simple mappings have a single character result,
+   * where the full mappings may have multi-character results. For more information, see Case
+   * and Case Mapping.
+   */
+  final private class UppercaseMapping private (val value: String) extends AnyVal
+
+  private object UppercaseMapping {
+    private def apply(value: String): UppercaseMapping =
+      new UppercaseMapping(value)
+
+    def fromString(value: String): Option[UppercaseMapping] =
+      if (value.nonEmpty) {
+        Some(UppercaseMapping(value))
+      } else {
+        None
+      }
+
+    implicit val hashAndOrderForUppercaseMapping
+        : Hash[UppercaseMapping] with Order[UppercaseMapping] =
+      new Hash[UppercaseMapping] with Order[UppercaseMapping] {
+        override def hash(x: UppercaseMapping): Int =
+          x.hashCode
+
+        override def compare(x: UppercaseMapping, y: UppercaseMapping): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[UppercaseMapping] =
+      hashAndOrderForUppercaseMapping.toOrdering
+  }
+
+  /**
+   * Newtype for Simple lowercase mapping.
+   */
+  final private class LowercaseMapping private (val value: String) extends AnyVal
+
+  private object LowercaseMapping {
+    private def apply(value: String): LowercaseMapping =
+      new LowercaseMapping(value)
+
+    def fromString(value: String): Option[LowercaseMapping] =
+      if (value.nonEmpty) {
+        Some(LowercaseMapping(value))
+      } else {
+        None
+      }
+
+    implicit val hashAndOrderForLowercaseMapping
+        : Hash[LowercaseMapping] with Order[LowercaseMapping] =
+      new Hash[LowercaseMapping] with Order[LowercaseMapping] {
+        override def hash(x: LowercaseMapping): Int =
+          x.hashCode
+
+        override def compare(x: LowercaseMapping, y: LowercaseMapping): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[LowercaseMapping] =
+      hashAndOrderForLowercaseMapping.toOrdering
+  }
+
+  /**
+   * Newtype for Simple titlecase mapping (single character result). Note: If this field is
+   * null, then the Simple_Titlecase_Mapping is the same as the Simple_Uppercase_Mapping for
+   * this character.
+   */
+  final private class TitlecaseMapping private (val value: String) extends AnyVal
+
+  private object TitlecaseMapping {
+    private def apply(value: String): TitlecaseMapping =
+      new TitlecaseMapping(value)
+
+    def fromString(value: String): Option[TitlecaseMapping] =
+      if (value.nonEmpty) {
+        Some(TitlecaseMapping(value))
+      } else {
+        None
+      }
+
+    implicit val hashAndOrderForTitlecaseMapping
+        : Hash[TitlecaseMapping] with Order[TitlecaseMapping] =
+      new Hash[TitlecaseMapping] with Order[TitlecaseMapping] {
+        override def hash(x: TitlecaseMapping): Int =
+          x.hashCode
+
+        override def compare(x: TitlecaseMapping, y: TitlecaseMapping): Int =
+          x.value.compare(y.value)
+      }
+
+    implicit val orderingInstance: Ordering[TitlecaseMapping] =
+      hashAndOrderForTitlecaseMapping.toOrdering
+  }
+
+  /**
+   * The information about a code point or range of code points as described in
+   * `UnicodeData.txt`
+   */
+  final private case class UnicodeCodePointInfomation(
+      name: Name,
+      generalCategory: GeneralCategory,
+      canonicalCombiningClass: CanonicalCombiningClass,
+      bidirectionalCategory: BidirectionalCategory,
+      characterDecompositionMapping: Option[CharacterDecompositionMapping],
+      decimalDigitValue: Option[DecimalDigitValue],
+      digitValue: Option[DigitValue],
+      numericValue: Option[NumericValue],
+      mirrored: Mirrored,
+      unicode1Name: Option[Unicode1Name],
+      iso10646Comment: Option[ISO10646Comment],
+      uppercaseMapping: Option[UppercaseMapping],
+      lowercaseMapping: Option[LowercaseMapping],
+      titlecaseMapping: Option[TitlecaseMapping]
+  )
+
+  private object UnicodeCodePointInfomation {
+    implicit val hashAndOrderForUnicodeCodePointInfomation
+        : Hash[UnicodeCodePointInfomation] with Order[UnicodeCodePointInfomation] = {
+      val order: Order[UnicodeCodePointInfomation] = semiauto.order
+
+      new Hash[UnicodeCodePointInfomation] with Order[UnicodeCodePointInfomation] {
+        override def hash(x: UnicodeCodePointInfomation): Int = x.hashCode
+
+        override def compare(
+            x: UnicodeCodePointInfomation,
+            y: UnicodeCodePointInfomation): Int =
+          order.compare(x, y)
+      }
+    }
+
+    implicit def orderingInstance: Ordering[UnicodeCodePointInfomation] =
+      hashAndOrderForUnicodeCodePointInfomation.toOrdering
+  }
+
+  /**
+   * A representation of a single row from `UnicodeData.txt`.
+   */
+  final private case class UnicodeDataRow(
+      codeValue: CodePoint,
+      rangeType: Option[RangeType],
+      unicodeCodePointInformation: UnicodeCodePointInfomation
+  )
+
+  private object UnicodeDataRow {
+
+    /**
+     * Regex for parsing a row from `UnicodeData.txt`.
+     */
+    private val rowRegex: Regex =
+      """([^;]*);([^;]*);([^;]*);([^;]*);([^;]*);([^;]*);([^;]*);([^;]*);([^;]*);([^;]*);([^;]*);([^;]*);([^;]*);([^;]*);([^;]*)""".r
+
+    /**
+     * Regex for detecting a row represnting the beginning of a code point range.
+     */
+    private val startRegex: Regex =
+      """\s*<([^,]+),\s*[fF]irst>\s*""".r
+
+    /**
+     * Regex for detecting a row represnting the end of a code point range.
+     */
+    private val endRegex: Regex =
+      """\s*<([^,]+),\s*[lL]ast>\s*""".r
+
+    /**
+     * Parse the name and range type from the first field of a row from `UnicodeData.txt`.
+     */
+    private def parseNameAndRange(value: String): (Option[RangeType], Name) =
+      value match {
+        case startRegex(name) =>
+          Some(RangeType.Start) -> Name(name)
+        case endRegex(name) =>
+          Some(RangeType.End) -> Name(name)
+        case name =>
+          None -> Name(name)
+      }
+
+    /**
+     * Parse a row from `UnicodeData.txt`.
+     */
+    def unsafeFromLine(value: String): UnicodeDataRow =
+      value.trim match {
+        case rowRegex(
+              codeValue,
+              nameAndRange,
+              generalCategory,
+              canonicalCombiningClass,
+              bidirectionalCategory,
+              characterDecompositionMapping,
+              decimalDigitValue,
+              digitValue,
+              numericValue,
+              mirrored,
+              unicode1Name,
+              iso10646Comment,
+              uppercaseMapping,
+              lowercaseMapping,
+              titlecaseMapping) =>
+          parseNameAndRange(nameAndRange) match {
+            case (rangeType, name) =>
+              UnicodeDataRow(
+                CodePoint.unsafeFromHexString(codeValue),
+                rangeType,
+                UnicodeCodePointInfomation(
+                  name,
+                  GeneralCategory(generalCategory),
+                  CanonicalCombiningClass.unsafeFromString(canonicalCombiningClass),
+                  BidirectionalCategory(bidirectionalCategory),
+                  CharacterDecompositionMapping.fromString(characterDecompositionMapping),
+                  DecimalDigitValue.unsafeFromString(decimalDigitValue),
+                  DigitValue.unsafeFromString(digitValue),
+                  NumericValue.fromString(numericValue),
+                  Mirrored.unsafeFromString(mirrored),
+                  Unicode1Name.fromString(unicode1Name),
+                  ISO10646Comment.fromString(iso10646Comment),
+                  UppercaseMapping.fromString(uppercaseMapping),
+                  LowercaseMapping.fromString(lowercaseMapping),
+                  TitlecaseMapping.fromString(titlecaseMapping)
+                )
+              )
+          }
+        case otherwise =>
+          throw new IllegalArgumentException(
+            s"Expected 15 fields in UnicodeData.txt row, but got ${otherwise.size}, in ${value}")
+      }
+
+    implicit val hashAndOrderForUnicodeDataRow
+        : Hash[UnicodeDataRow] with Order[UnicodeDataRow] = {
+      val order: Order[UnicodeDataRow] = semiauto.order
+
+      new Hash[UnicodeDataRow] with Order[UnicodeDataRow] {
+        override def hash(x: UnicodeDataRow): Int = x.hashCode
+
+        override def compare(x: UnicodeDataRow, y: UnicodeDataRow): Int =
+          order.compare(x, y)
+      }
+    }
+
+    implicit def orderingInstance: Ordering[UnicodeDataRow] =
+      hashAndOrderForUnicodeDataRow.toOrdering
+  }
+
+  /**
+   * A representation of the data from `UnicodeData.txt`, indexable by [[CodePointRange]].
+   */
+  final private case class UnicodeData(
+      codePoints: SortedMap[CodePointRange, UnicodeCodePointInfomation]
+  ) {
+
+    /**
+     * The data partitioned into sets of [[UnicodeCodePointInfomation]] which pertain to a
+     * single code point and a range of code points. This partitioning is important for
+     * optimizing the generated code.
+     */
+    lazy val partitioned: (
+        SortedMap[CodePointRange.Single, UnicodeCodePointInfomation],
+        SortedMap[CodePointRange, UnicodeCodePointInfomation]) =
+      codePoints.foldLeft(
+        (
+          SortedMap.empty[CodePointRange.Single, UnicodeCodePointInfomation],
+          SortedMap.empty[CodePointRange, UnicodeCodePointInfomation])) {
+        case ((singles, ranges), (k: CodePointRange.Single, v)) =>
+          (singles + (k -> v), ranges)
+        case ((singles, ranges), (k, v)) =>
+          (singles, ranges + (k -> v))
+      }
+
+    def singles: SortedMap[CodePointRange.Single, UnicodeCodePointInfomation] =
+      partitioned._1
+
+    def ranges: SortedMap[CodePointRange, UnicodeCodePointInfomation] =
+      partitioned._2
+  }
+
+  private object UnicodeData {
+    val empty: UnicodeData = UnicodeData(SortedMap.empty)
+
+    implicit val hashAndOrderForUnicodeData: Hash[UnicodeData] with Order[UnicodeData] = {
+      val order: Order[UnicodeData] =
+        semiauto.order
+      new Hash[UnicodeData] with Order[UnicodeData] {
+        override def hash(x: UnicodeData): Int =
+          x.hashCode
+
+        override def compare(x: UnicodeData, y: UnicodeData): Int =
+          order.compare(x, y)
+      }
+    }
+
+    implicit val orderingInstance: Ordering[UnicodeData] =
+      hashAndOrderForUnicodeData.toOrdering
+  }
+
+  /**
+   * Convert rows into an instance of [[UnicodeData]]
+   *
+   * The primary purpose of this function is to deal with the start/end range rows.
+   */
+  private def rowsToUnicodeData(rows: Chain[UnicodeDataRow]): Either[String, UnicodeData] =
+    rows.foldMap(row =>
+      row
+        .rangeType
+        .fold(
+          (SortedSet(row), SortedMap.empty[Name, NonEmptyChain[UnicodeDataRow]])
+        )(_ =>
+          (
+            SortedSet.empty[UnicodeDataRow],
+            SortedMap[Name, NonEmptyChain[UnicodeDataRow]](
+              row.unicodeCodePointInformation.name -> NonEmptyChain.one(row))))) match {
+      case (singleCodePoints, rangesOfCodePoints) =>
+        type F[A] = Either[String, A]
+        rangesOfCodePoints
+          .toList
+          .map(_._2)
+          .foldM[F, UnicodeData](UnicodeData.empty) {
+            case (acc, values) =>
+              values.toList match {
+                case a :: b :: Nil =>
+                  def from(
+                      startRow: UnicodeDataRow,
+                      endRow: UnicodeDataRow): Either[String, UnicodeData] =
+                    if (startRow.unicodeCodePointInformation === endRow.unicodeCodePointInformation) {
+                      CodePointRange
+                        .from(startRow.codeValue, endRow.codeValue)
+                        .flatMap(range =>
+                          Right(
+                            acc.copy(
+                              codePoints =
+                                acc.codePoints + (range -> startRow.unicodeCodePointInformation)
+                            )
+                          ))
+                    } else {
+                      Left(
+                        s"Code point description is mismatched, but it should be the same for a given range: $a, $b")
+                    }
+
+                  (a.rangeType, b.rangeType) match {
+                    case (Some(RangeType.Start), Some(RangeType.End)) =>
+                      from(a, b)
+                    case (Some(RangeType.End), Some(RangeType.Start)) =>
+                      from(b, a)
+                    case _ =>
+                      Left(
+                        s"Both range types are the same, but we expected a Start and an End: $a, $b")
+                  }
+                case otherwise =>
+                  Left(
+                    s"Expected two rows for a range, a start and an end, but got: ${otherwise}")
+              }
+          }
+          .map(value =>
+            singleCodePoints.foldLeft(value) {
+              case (acc, value) =>
+                acc.copy(codePoints = acc.codePoints + (CodePointRange(
+                  value.codeValue) -> value.unicodeCodePointInformation))
+            })
+    }
+
+  /**
+   * Extract the subset of Unicode code points which have the General_Category=Mark, e.g. a
+   * combining mark.
+   */
+  private def filterToGeneralCategoryMark(value: UnicodeData): UnicodeData =
+    UnicodeData(
+      value.codePoints.filter {
+        case (_, v) =>
+          v.generalCategory.isCombiningMark
+      }
+    )
+
+  /**
+   * Create the term representing the `BitSet` of all the Unicode code points which have a
+   * general category of "Mark", e.g. a combining mark.
+   */
+  private def combiningMarkExpression(unicodeData: UnicodeData): Term =
+    filterToGeneralCategoryMark(unicodeData) match {
+      case unicodeData =>
+        val ranges: SortedSet[CodePointRange] = unicodeData.ranges.keySet
+        val singles: SortedSet[CodePoint]     = unicodeData.singles.keySet.map(_.value)
+        val rangeTerms: List[Term] =
+          ranges
+            .toList
+            .map(range =>
+              q"Range.inclusive(${Lit.Int(range.lower.value)}, ${Lit.Int(range.upper.value)})")
+        val singlesTerm: Term =
+          q"BitSet(..${singles.toList.map(value => Lit.Int(value.value))})"
+        if (rangeTerms.isEmpty) {
+          singlesTerm
+        } else {
+          q"List(..$rangeTerms).foldLeft($singlesTerm)(_.fromScalaRange(_)).compact"
+        }
+    }
+
+  /**
+   * Create the defs needed for the bidirectional information about Unicode code points.
+   */
+  private def bidirectionalCategoryDefs(unicodeData: UnicodeData): List[Defn] = {
+    val grouped: SortedMap[CodePointRange, BidirectionalCategory] =
+      group(
+        mapValues(
+          unicodeData.codePoints,
+          (value: UnicodeCodePointInfomation) => value.bidirectionalCategory))
+    val (ranges, singles): (
+        SortedMap[CodePointRange, BidirectionalCategory],
+        SortedMap[CodePointRange, BidirectionalCategory]) = grouped.partition {
+      case (k, _) => k.size > 1
+    }
+    val rangeTerms: List[Term] = ranges.toList.map {
+      case (k, v) =>
+        q"(Range.inclusive(${Lit.Int(k.lower.value)}, ${Lit.Int(k.upper.value)}), ${Lit.String(v.value)})"
+    }
+    val singleTerms: List[Term] =
+      singles.toList.map {
+        case (k, v) =>
+          q"(${Lit.Int(k.lower.value)}, ${Lit.String(v.value)})"
+      }
+    val baseMap: Term =
+      q"IntMap(..$singleTerms)"
+
+    List(
+      q"""private final def bidirectionalCategoryBaseMap: IntMap[String] = $baseMap""",
+      q"""override final protected lazy val bidirectionalCategoryMap: IntMap[String] =
+             List[(Range, String)](..$rangeTerms).foldLeft(bidirectionalCategoryBaseMap){
+              case (k, (range, result)) =>
+                range.foldLeft(k){
+                  case (k, cp) =>
+                    k.updated(cp, result)
+                }
+          }"""
+    )
+  }
+
+  /**
+   * Extract out the Unicode code points which have a canonical combining class of Virama. This
+   * is the only class we need to know about for UTS-46.
+   */
+  private def filterToVirama(value: UnicodeData): SortedSet[CodePointRange] =
+    group(
+      mapValues(
+        value.codePoints,
+        (value: UnicodeCodePointInfomation) => value.canonicalCombiningClass))
+      .foldLeft(SortedSet.empty[CodePointRange]) {
+        case (acc, (k, v)) =>
+          if (v.isVirama) {
+            acc + k
+          } else {
+            acc
+          }
+      }
+
+  /**
+   * Generate the defs needed to create the BitSets for tracking the Unicode code points which
+   * have a canonical combining class of Virama.
+   */
+  private def viramaCanonicalCombiningClassCodePointsDefs(
+      unicodeData: UnicodeData): List[Defn] = {
+    val grouped: SortedSet[CodePointRange] =
+      filterToVirama(unicodeData)
+    val (ranges, singles): (SortedSet[CodePointRange], SortedSet[CodePointRange]) =
+      grouped.partition(_.size > 1)
+
+    val rangeTerms: List[Term] = ranges.toList.map {
+      case value =>
+        q"(Range.inclusive(${Lit.Int(value.lower.value)}, ${Lit.Int(value.upper.value)}))"
+    }
+
+    val singleTerms: List[Term] = singles.toList.map {
+      case value =>
+        Lit.Int(value.lower.value)
+    }
+
+    val base: Term =
+      q"BitSet(..$singleTerms)"
+
+    List(
+      q"private final def viramaCanonicalCombiningClassCodePointsBase: BitSet = $base",
+      q"""override final protected lazy val viramaCanonicalCombiningClassCodePoints: BitSet =
+            List[Range](..$rangeTerms).foldLeft(viramaCanonicalCombiningClassCodePointsBase){
+              case (acc, range) =>
+                range.foldLeft(acc){ case (acc, cp) => acc + cp}
+            }
+       """
+    )
+  }
+
+  // Utility functions for working with Maps
+
+  /**
+   * For a given `SortedMap`, invert the mapping.
+   */
+  private def invertMapping[A: Order, B: Ordering: Order](
+      value: SortedMap[A, B]): SortedMap[B, NonEmptySet[A]] =
+    value.toList.foldMap {
+      case (k, v) =>
+        SortedMap(v -> NonEmptySet.one(k))
+    }
+
+  /**
+   * For a map of code point range values to some type `A`, collapse ranges of code points which
+   * map to the same `A` into a single code point range. This becomes useful when we are
+   * interested in a certain sub-property of a code point, for example the "General_Category".
+   * When initially parsing the data from `UnicodeData.txt`, these code points might have been
+   * in separate rows because they didn't share all of the code point properties, but after
+   * projecting to a specific sub-property they may be collapsable into a single range.
+   *
+   * By grouping these values when we can, we make the size of the generated code smaller.
+   */
+  private def group[A: Eq: Ordering: Order](
+      value: SortedMap[CodePointRange, A]): SortedMap[CodePointRange, A] = {
+    invertMapping(value).foldLeft(SortedMap.empty[CodePointRange, A]) {
+      // Remember we just inverted this.
+      case (acc, (value, keys)) =>
+        keys
+          .foldLeft((acc, Option.empty[CodePointRange])) {
+            case ((acc, previous), key) =>
+              previous.fold(
+                (acc + (key -> value), Some(key))
+              )(previous =>
+                if (previous.upper.value < Character.MAX_CODE_POINT && (previous
+                    .upper
+                    .value + 1) === key.lower.value) {
+                  val newRange: CodePointRange =
+                    CodePointRange.unsafeFrom(previous.lower, key.upper)
+                  ((acc - previous) + (newRange -> value), Some(newRange))
+                } else {
+                  (acc + (key -> value), Some(key))
+                })
+          }
+          ._1
+    }
+  }
+
+  /**
+   * Missing in 2.12.x, deprecated in 2.13.x, so reproduced here.
+   */
+  private def mapValues[A: Ordering, B, C](value: SortedMap[A, B], f: B => C): SortedMap[A, C] =
+    value.foldLeft(SortedMap.empty[A, C]) {
+      case (acc, (k, v)) =>
+        acc + (k -> f(v))
+    }
+}

--- a/project/UnicodeVersion.scala
+++ b/project/UnicodeVersion.scala
@@ -1,21 +1,108 @@
 package org.typelevel.idna4s.build
 
 import cats._
+import scala.util.matching.Regex
 
-/**
- * Newtype for a Unicode version string.
- */
-final private[build] case class UnicodeVersion(value: String) extends AnyVal
+sealed abstract private[build] class UnicodeVersion extends Serializable {
+  def asString: String
+}
 
-object UnicodeVersion {
-  val Latest: UnicodeVersion = UnicodeVersion("latest")
+private[build] object UnicodeVersion {
+
+  def fromString(value: String): Either[String, UnicodeVersion] =
+    value.trim.toLowerCase match {
+      case "latest" =>
+        Right(Latest)
+      case otherwise =>
+        Numeric.fromString(otherwise)
+    }
+
+  def unsafeFromString(value: String): UnicodeVersion =
+    fromString(value).fold(
+      e => throw new IllegalArgumentException(e),
+      identity
+    )
+
+  sealed abstract class Numeric extends UnicodeVersion {
+    def major: String
+    def minor: String
+    def patch: String
+
+    final override def asString: String = s"${major}.${minor}.${patch}"
+
+    final override def toString: String =
+      s"UnicodeVersion.Numeric(major = ${major}, minor = ${minor}, patch = ${patch})"
+  }
+
+  object Numeric {
+    final private[this] case class NumericImpl(
+        override val major: String,
+        override val minor: String,
+        override val patch: String)
+        extends Numeric
+
+    private val versionRegex: Regex =
+      """\s*([1-9]\d*|0)\.([1-9]\d*|0)\.([1-9]\d*|0)\s*""".r
+
+    def fromString(value: String): Either[String, Numeric] =
+      value match {
+        case versionRegex(major, minor, patch) =>
+          Right(NumericImpl(major, minor, patch))
+        case _ =>
+          Left(s"Given string is not a valid Unicode version: ${value}")
+      }
+
+    def unsafeFromString(value: String): Numeric =
+      fromString(value).fold(
+        e => throw new IllegalArgumentException(e),
+        identity
+      )
+
+    def fromLongs(major: Long, minor: Long, patch: Long): Either[String, Numeric] =
+      if (major >= 0L && minor >= 0L && patch >= 0L) {
+        Right(NumericImpl(major.toString, minor.toString, patch.toString))
+      } else {
+        Left(s"A numeric Unicode version value can not have negative components.")
+      }
+
+    def unsafeFromLongs(major: Long, minor: Long, patch: Long): Numeric =
+      fromLongs(major, minor, patch).fold(
+        s => throw new IllegalArgumentException(s),
+        identity
+      )
+  }
+
+  case object Latest extends UnicodeVersion {
+    final override def asString: String = "latest"
+
+    override val toString: String = "UnicodeVersion.Latest"
+  }
 
   implicit val hashAndOrderForUnicodeVersion: Hash[UnicodeVersion] with Order[UnicodeVersion] =
     new Hash[UnicodeVersion] with Order[UnicodeVersion] {
       override def hash(x: UnicodeVersion): Int = x.hashCode
 
       override def compare(x: UnicodeVersion, y: UnicodeVersion): Int =
-        x.value.compare(y.value)
+        (x, y) match {
+          case (Latest, Latest) =>
+            0
+          case (Latest, _) =>
+            1
+          case (_, Latest) =>
+            -1
+          case (x: Numeric, y: Numeric) =>
+            x.major.compare(y.major) match {
+              case 0 =>
+                x.minor.compare(y.minor) match {
+                  case 0 =>
+                    x.patch.compare(y.patch)
+                  case otherwise =>
+                    otherwise
+                }
+              case otherwise =>
+                otherwise
+            }
+        }
     }
 
   implicit def orderingInstance: Ordering[UnicodeVersion] =

--- a/project/UnicodeVersion.scala
+++ b/project/UnicodeVersion.scala
@@ -1,0 +1,23 @@
+package org.typelevel.idna4s.build
+
+import cats._
+
+/**
+ * Newtype for a Unicode version string.
+ */
+final private[build] case class UnicodeVersion(value: String) extends AnyVal
+
+object UnicodeVersion {
+  val Latest: UnicodeVersion = UnicodeVersion("latest")
+
+  implicit val hashAndOrderForUnicodeVersion: Hash[UnicodeVersion] with Order[UnicodeVersion] =
+    new Hash[UnicodeVersion] with Order[UnicodeVersion] {
+      override def hash(x: UnicodeVersion): Int = x.hashCode
+
+      override def compare(x: UnicodeVersion, y: UnicodeVersion): Int =
+        x.value.compare(y.value)
+    }
+
+  implicit def orderingInstance: Ordering[UnicodeVersion] =
+    hashAndOrderForUnicodeVersion.toOrdering
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.7.3

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -12,3 +12,9 @@ libraryDependencies ++= List(
   "org.typelevel" %% "cats-core"         % "2.8.0",
   "org.typelevel" %% "kittens"           % "3.0.0"
 )
+
+libraryDependencies ++= List(
+  "org.scalameta" %%% "munit-scalacheck" % "1.0.0-M6" % Test,
+  "org.typelevel" %%% "cats-laws"        % "2.8.0"    % Test,
+  "org.typelevel" %%% "discipline-munit" % "2.0.0-M3" % Test
+)

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -9,5 +9,6 @@ scalacOptions -= "-Ywarn-unused-import"
 libraryDependencies ++= List(
   "org.scalameta"  % "semanticdb-scalac" % "4.6.0" cross CrossVersion.full,
   "org.scalameta" %% "scalameta"         % "4.6.0",
-  "org.typelevel" %% "cats-core"         % "2.8.0"
+  "org.typelevel" %% "cats-core"         % "2.8.0",
+  "org.typelevel" %% "kittens"           % "3.0.0"
 )

--- a/project/src/test/scala/org/typelevel/idna4s/build/LawsChecks.scala
+++ b/project/src/test/scala/org/typelevel/idna4s/build/LawsChecks.scala
@@ -1,0 +1,75 @@
+package org.typelevel.idna4s.build
+
+import cats.kernel.laws.discipline._
+import munit._
+import org.typelevel.idna4s.build.ScalacheckInstances._
+import org.typelevel.idna4s.build.UTS46CodeGen._
+import org.typelevel.idna4s.build.UnicodeDataCodeGen._
+
+final class LawChecks extends DisciplineSuite {
+  checkAll("Order[UnicodeVersion]", OrderTests[UnicodeVersion].order)
+  checkAll("Hash[UnicodeVersion]", HashTests[UnicodeVersion].hash)
+
+  checkAll("Order[CodePoint]", OrderTests[CodePoint].order)
+
+  checkAll("Order[IDNA2008Status]", OrderTests[IDNA2008Status].order)
+
+  checkAll("Order[CodePointRange]", OrderTests[CodePointRange].order)
+  checkAll("Hash[CodePointRange]", HashTests[CodePointRange].hash)
+
+  checkAll("Order[RangeType]", OrderTests[RangeType].order)
+  checkAll("Hash[RangeType]", HashTests[RangeType].hash)
+
+  checkAll("Order[GeneralCategory]", OrderTests[GeneralCategory].order)
+  checkAll("Hash[GeneralCategory]", HashTests[GeneralCategory].hash)
+
+  checkAll("Order[Name]", OrderTests[Name].order)
+  checkAll("Hash[Name]", HashTests[Name].hash)
+
+  checkAll("Order[CanonicalCombiningClass]", OrderTests[CanonicalCombiningClass].order)
+  checkAll("Hash[CanonicalCombiningClass]", HashTests[CanonicalCombiningClass].hash)
+
+  checkAll("Order[BidirectionalCategory]", OrderTests[BidirectionalCategory].order)
+  checkAll("Hash[BidirectionalCategory]", HashTests[BidirectionalCategory].hash)
+
+  checkAll(
+    "Order[CharacterDecompositionMapping]",
+    OrderTests[CharacterDecompositionMapping].order)
+  checkAll("Hash[CharacterDecompositionMapping]", HashTests[CharacterDecompositionMapping].hash)
+
+  checkAll("Order[DecimalDigitValue]", OrderTests[DecimalDigitValue].order)
+  checkAll("Hash[DecimalDigitValue]", HashTests[DecimalDigitValue].hash)
+
+  checkAll("Order[DigitValue]", OrderTests[DigitValue].order)
+  checkAll("Hash[DigitValue]", HashTests[DigitValue].hash)
+
+  checkAll("Order[NumericValue]", OrderTests[NumericValue].order)
+  checkAll("Hash[NumericValue]", HashTests[NumericValue].hash)
+
+  checkAll("Order[Mirrored]", OrderTests[Mirrored].order)
+  checkAll("Hash[Mirrored]", HashTests[Mirrored].hash)
+
+  checkAll("Order[Unicode1Name]", OrderTests[Unicode1Name].order)
+  checkAll("Hash[Unicode1Name]", HashTests[Unicode1Name].hash)
+
+  checkAll("Order[ISO10646Comment]", OrderTests[ISO10646Comment].order)
+  checkAll("Hash[ISO10646Comment]", HashTests[ISO10646Comment].hash)
+
+  checkAll("Order[UppercaseMapping]", OrderTests[UppercaseMapping].order)
+  checkAll("Hash[UppercaseMapping]", HashTests[UppercaseMapping].hash)
+
+  checkAll("Order[LowercaseMapping]", OrderTests[LowercaseMapping].order)
+  checkAll("Hash[LowercaseMapping]", HashTests[LowercaseMapping].hash)
+
+  checkAll("Order[TitlecaseMapping]", OrderTests[TitlecaseMapping].order)
+  checkAll("Hash[TitlecaseMapping]", HashTests[TitlecaseMapping].hash)
+
+  checkAll("Order[UnicodeCodePointInfomation]", OrderTests[UnicodeCodePointInfomation].order)
+  checkAll("Hash[UnicodeCodePointInfomation]", HashTests[UnicodeCodePointInfomation].hash)
+
+  checkAll("Order[UnicodeDataRow]", OrderTests[UnicodeDataRow].order)
+  checkAll("Hash[UnicodeDataRow]", HashTests[UnicodeDataRow].hash)
+
+  checkAll("Order[UnicodeData[Int]]", OrderTests[UnicodeData[Int]].order)
+  checkAll("Hash[UnicodeData[Int]]", HashTests[UnicodeData[Int]].hash)
+}

--- a/project/src/test/scala/org/typelevel/idna4s/build/ScalacheckInstances.scala
+++ b/project/src/test/scala/org/typelevel/idna4s/build/ScalacheckInstances.scala
@@ -1,0 +1,275 @@
+package org.typelevel.idna4s.build
+
+import cats._
+import org.scalacheck._
+import org.typelevel.idna4s.build.UTS46CodeGen._
+import org.typelevel.idna4s.build.UnicodeDataCodeGen._
+import scala.collection.immutable.SortedMap
+
+object ScalacheckInstances {
+  private def genNonEmptyString(implicit A: Arbitrary[String]): Gen[String] =
+    A.arbitrary.suchThat(_.size > 0)
+
+  val genUnicodeNumericVersion: Gen[UnicodeVersion.Numeric] =
+    for {
+      major <- Gen.choose(0L, Long.MaxValue)
+      minor <- Gen.choose(0L, Long.MaxValue)
+      patch <- Gen.choose(0L, Long.MaxValue)
+    } yield UnicodeVersion.Numeric.unsafeFromLongs(major, minor, patch)
+
+  implicit val arbUnicodeVersion: Arbitrary[UnicodeVersion] =
+    Arbitrary(
+      Gen.oneOf(
+        genUnicodeNumericVersion,
+        Gen.const(UnicodeVersion.Latest)
+      )
+    )
+
+  implicit lazy val cogenUnicodeVersion: Cogen[UnicodeVersion] =
+    Cogen[String].contramap(_.asString)
+
+  implicit val chooseCodePoint: Gen.Choose[CodePoint] =
+    Gen.Choose.xmap(CodePoint.unsafeFromInt, _.value)
+
+  implicit val arbCodePoint: Arbitrary[CodePoint] =
+    Arbitrary(
+      Gen.choose(CodePoint.unsafeFromInt(0), CodePoint.unsafeFromInt(Character.MAX_CODE_POINT))
+    )
+
+  implicit val cogenCodePoint: Cogen[CodePoint] =
+    Cogen[Int].contramap(_.value)
+
+  implicit val arbIDNA2008Status: Arbitrary[IDNA2008Status] =
+    Arbitrary(
+      Gen.oneOf(IDNA2008Status.NV8, IDNA2008Status.XV8)
+    )
+
+  implicit val cogenIDNA2008Status: Cogen[IDNA2008Status] =
+    Cogen[String].contramap(_.asString)
+
+  implicit val arbCodePointRange: Arbitrary[CodePointRange] =
+    Arbitrary(
+      Arbitrary
+        .arbitrary[CodePoint]
+        .flatMap(lower =>
+          Gen
+            .choose(lower, CodePoint.unsafeFromInt(Character.MAX_CODE_POINT))
+            .map(upper => CodePointRange.unsafeFrom(lower, upper)))
+    )
+
+  implicit val cogenCodePointRange: Cogen[CodePointRange] =
+    Cogen[(CodePoint, CodePoint)].contramap(value => (value.lower, value.upper))
+
+  implicit val arbRangeType: Arbitrary[RangeType] =
+    Arbitrary(
+      Gen.oneOf(RangeType.Start, RangeType.End)
+    )
+
+  implicit val cogenRangeType: Cogen[RangeType] =
+    Cogen[Int].contramap {
+      case RangeType.Start => 0
+      case RangeType.End => 1
+    }
+
+  implicit val arbGeneralCategory: Arbitrary[GeneralCategory] =
+    Arbitrary(
+      Arbitrary.arbitrary[String].map(GeneralCategory.apply)
+    )
+
+  implicit val cogenGeneralCategory: Cogen[GeneralCategory] =
+    Cogen[String].contramap(_.value)
+
+  implicit val arbName: Arbitrary[Name] =
+    Arbitrary(
+      Arbitrary.arbitrary[String].map(Name.apply)
+    )
+
+  implicit val cogenName: Cogen[Name] =
+    Cogen[String].contramap(_.value)
+
+  implicit val arbCanonicalCombiningClass: Arbitrary[CanonicalCombiningClass] =
+    Arbitrary(
+      Arbitrary.arbitrary[Int].map(CanonicalCombiningClass.apply)
+    )
+
+  implicit val cogenCanonicalCombiningClass: Cogen[CanonicalCombiningClass] =
+    Cogen[Int].contramap(_.value)
+
+  implicit val arbBidirectionalCategory: Arbitrary[BidirectionalCategory] =
+    Arbitrary(
+      Arbitrary.arbitrary[String].map(BidirectionalCategory.apply)
+    )
+
+  implicit val cogenBidirectionalCategory: Cogen[BidirectionalCategory] =
+    Cogen[String].contramap(_.value)
+
+  implicit val arbCharacterDecompositionMapping: Arbitrary[CharacterDecompositionMapping] =
+    Arbitrary(
+      genNonEmptyString.map(CharacterDecompositionMapping.unsafeFromString)
+    )
+
+  implicit val cogenCharacterDecompositionMapping: Cogen[CharacterDecompositionMapping] =
+    Cogen[String].contramap(_.value)
+
+  implicit val arbDecimalDecimalDigitValue: Arbitrary[DecimalDigitValue] =
+    Arbitrary(
+      Gen.choose(0, 9).map(DecimalDigitValue.unsafeFromInt)
+    )
+
+  implicit val cogenDecimalDigitValue: Cogen[DecimalDigitValue] =
+    Cogen[Int].contramap(_.value)
+
+  implicit val arbDigitValue: Arbitrary[DigitValue] =
+    Arbitrary(
+      Gen.choose(0, Int.MaxValue).map(DigitValue.unsafeFromInt)
+    )
+
+  implicit val cogenDigitValue: Cogen[DigitValue] =
+    Cogen[Int].contramap(_.value)
+
+  implicit val arbNumericValue: Arbitrary[NumericValue] =
+    Arbitrary(
+      genNonEmptyString.map(NumericValue.unsafeFromString)
+    )
+
+  implicit val cogenNumericValue: Cogen[NumericValue] =
+    Cogen[String].contramap(_.value)
+
+  implicit val arbMirroredValue: Arbitrary[Mirrored] =
+    Arbitrary(
+      Arbitrary.arbitrary[Boolean].map(Mirrored.apply)
+    )
+
+  implicit val cogenMirroedValue: Cogen[Mirrored] =
+    Cogen[Boolean].contramap(_.value)
+
+  implicit val arbUnicode1Name: Arbitrary[Unicode1Name] =
+    Arbitrary(
+      genNonEmptyString.map(Unicode1Name.unsafeFromString)
+    )
+
+  implicit val cogenUnicode1Name: Cogen[Unicode1Name] =
+    Cogen[String].contramap(_.value)
+
+  implicit val arbISO10646Comment: Arbitrary[ISO10646Comment] =
+    Arbitrary(
+      genNonEmptyString.map(ISO10646Comment.unsafeFromString)
+    )
+
+  implicit val cogenISO10646Comment: Cogen[ISO10646Comment] =
+    Cogen[String].contramap(_.value)
+
+  implicit val arbUppercaseMapping: Arbitrary[UppercaseMapping] =
+    Arbitrary(
+      genNonEmptyString.map(UppercaseMapping.unsafeFromString)
+    )
+
+  implicit val cogenUppercaseMapping: Cogen[UppercaseMapping] =
+    Cogen[String].contramap(_.value)
+
+  implicit val arbLowercaseMapping: Arbitrary[LowercaseMapping] =
+    Arbitrary(
+      genNonEmptyString.map(LowercaseMapping.unsafeFromString)
+    )
+
+  implicit val cogenLowercaseMapping: Cogen[LowercaseMapping] =
+    Cogen[String].contramap(_.value)
+
+  implicit val arbTitlecaseMapping: Arbitrary[TitlecaseMapping] =
+    Arbitrary(
+      genNonEmptyString.map(TitlecaseMapping.unsafeFromString)
+    )
+
+  implicit val cogenTitlecaseMapping: Cogen[TitlecaseMapping] =
+    Cogen[String].contramap(_.value)
+
+  implicit val arbUnicodeCodePointInformation: Arbitrary[UnicodeCodePointInfomation] =
+    Arbitrary(
+      for {
+        name <- Arbitrary.arbitrary[Name]
+        generalCategory <- Arbitrary.arbitrary[GeneralCategory]
+        canonicalCombiningClass <- Arbitrary.arbitrary[CanonicalCombiningClass]
+        bidirectionalCategory <- Arbitrary.arbitrary[BidirectionalCategory]
+        characterDecompositionMapping <- Arbitrary
+          .arbitrary[Option[CharacterDecompositionMapping]]
+        decimalDigitValue <- Arbitrary.arbitrary[Option[DecimalDigitValue]]
+        digitValue <- Arbitrary.arbitrary[Option[DigitValue]]
+        numericValue <- Arbitrary.arbitrary[Option[NumericValue]]
+        mirrored <- Arbitrary.arbitrary[Mirrored]
+        unicode1Name <- Arbitrary.arbitrary[Option[Unicode1Name]]
+        iso10646Comment <- Arbitrary.arbitrary[Option[ISO10646Comment]]
+        uppercaseMapping <- Arbitrary.arbitrary[Option[UppercaseMapping]]
+        lowercaseMapping <- Arbitrary.arbitrary[Option[LowercaseMapping]]
+        titlecaseMapping <- Arbitrary.arbitrary[Option[TitlecaseMapping]]
+      } yield UnicodeCodePointInfomation(
+        name,
+        generalCategory,
+        canonicalCombiningClass,
+        bidirectionalCategory,
+        characterDecompositionMapping,
+        decimalDigitValue,
+        digitValue,
+        numericValue,
+        mirrored,
+        unicode1Name,
+        iso10646Comment,
+        uppercaseMapping,
+        lowercaseMapping,
+        titlecaseMapping
+      ))
+
+  implicit val cogenUnicodeCodePointInfomation: Cogen[UnicodeCodePointInfomation] =
+    Cogen[(
+        Name,
+        GeneralCategory,
+        CanonicalCombiningClass,
+        BidirectionalCategory,
+        Option[CharacterDecompositionMapping],
+        Option[DecimalDigitValue],
+        Option[DigitValue],
+        Option[NumericValue],
+        Mirrored,
+        Option[Unicode1Name],
+        Option[ISO10646Comment],
+        Option[UppercaseMapping],
+        Option[LowercaseMapping],
+        Option[TitlecaseMapping])].contramap(value =>
+      (
+        value.name,
+        value.generalCategory,
+        value.canonicalCombiningClass,
+        value.bidirectionalCategory,
+        value.characterDecompositionMapping,
+        value.decimalDigitValue,
+        value.digitValue,
+        value.numericValue,
+        value.mirrored,
+        value.unicode1Name,
+        value.iso10646Comment,
+        value.uppercaseMapping,
+        value.lowercaseMapping,
+        value.titlecaseMapping))
+
+  implicit val arbUnicodeDataRow: Arbitrary[UnicodeDataRow] =
+    Arbitrary(
+      for {
+        codeValue <- Arbitrary.arbitrary[CodePoint]
+        rangeType <- Arbitrary.arbitrary[Option[RangeType]]
+        unicodeCodePointInformation <- Arbitrary.arbitrary[UnicodeCodePointInfomation]
+      } yield UnicodeDataRow(codeValue, rangeType, unicodeCodePointInformation)
+    )
+
+  implicit val cogenUnicodeDataRow: Cogen[UnicodeDataRow] =
+    Cogen[(CodePoint, Option[RangeType], UnicodeCodePointInfomation)].contramap(value =>
+      (value.codeValue, value.rangeType, value.unicodeCodePointInformation))
+
+  implicit def arbUnicodeData[A: Arbitrary: Order]: Arbitrary[UnicodeData[A]] =
+    Arbitrary(
+      Arbitrary.arbitrary[SortedMap[CodePointRange, A]].map(value => UnicodeData(value))
+    )
+
+  implicit def cogenUnicodeData[A: Cogen]: Cogen[UnicodeData[A]] =
+    Cogen[Map[CodePointRange, A]].contramap(
+      _.asSortedMap.toMap
+    )
+}


### PR DESCRIPTION
This commit adds the code generation code for the data we need to derive from `UnicodeData.txt` (https://www.unicode.org/Public/15.0.0/ucd/UnicodeData.txt).

This includes,

* Code points which are part of the `General_Category=Mark`, e.g. combining marks.
* Code points which have a Virama canonical combining class.
* The bidirectional category for all Unicode code points.

The code generation has been restructured. There is a single entry point for all code generation which ensures that all the code is generated with the same parameters, namely the unicode version.

It should be noted there are not tests in this commit. In the spirit of trying to keep this already rather large commit still reasonably sized, I decided to punt those to another commit. In order to meaningfully test this, we have to not only do the code generation, but also have logic operating on the data for UTS-46, which would make this commit huge.

Closes #28
Closes #26 