### PR TITLE
Fix Tests With icu4j

### DIFF
--- a/benchmarks/src/main/scala/org/typelevel/idna4s/benchmarks/uts46/ICU4J.scala
+++ b/benchmarks/src/main/scala/org/typelevel/idna4s/benchmarks/uts46/ICU4J.scala
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import org.scalacheck._
 import org.typelevel.idna4s.core.uts46._
+import java.text.Normalizer
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -53,7 +54,7 @@ class ICU4J {
 
   @Benchmark
   def idna4sUTS46: Either[CodePointMapper.MappingException, String] =
-    CodePointMapper.mapCodePoints(nextString)
+    CodePointMapper.mapCodePoints(Normalizer.normalize(nextString, Normalizer.Form.NFC))
 
   @Benchmark
   def icu4jUTS46: String =
@@ -63,7 +64,7 @@ class ICU4J {
 
   @Benchmark
   def idna4sUTS46ASCII: Either[CodePointMapper.MappingException, String] =
-    CodePointMapper.mapCodePoints(nextASCIIString)
+    CodePointMapper.mapCodePoints(Normalizer.normalize(nextASCIIString, Normalizer.Form.NFC))
 
   @Benchmark
   def icu4jUTS46ASCII: String =

--- a/build.sbt
+++ b/build.sbt
@@ -161,7 +161,7 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.typelevel" %%% "discipline-munit" % disciplineMunitV,
       "org.typelevel" %%% "cats-laws"        % catsV
     ),
-    console / initialCommands := {
+    Test / console / initialCommands := {
       List(
         "cats.",
         "cats.syntax.all.",


### PR DESCRIPTION
icu4j is performing an NFC normalization before running the UTS-46 mapping step. In order to be consistent in comparing with that result we must do the same.