### PR TITLE
Fix Missing `isVirama` Predicate Call

### DIFF
--- a/project/UnicodeDataCodeGen.scala
+++ b/project/UnicodeDataCodeGen.scala
@@ -980,6 +980,10 @@ private[uts46] trait ${Type.Name(GeneratedTypeName)} extends ${Init(
       .mapValues(
         _.canonicalCombiningClass
       )
+      .filter {
+        case (_, v) =>
+          v.isVirama
+      }
       .partitionedKeySets
 
   /**


### PR DESCRIPTION
Got lost in a refactor.

Tests for this will be coming in the branch which adds `toUnicode` and `toASCII`.