### PR TITLE
Fix `startYear` to 2022

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -10,7 +10,7 @@ scalacOptions -= "-Ywarn-unused-import"
 // sbt-typelevel for the meta project build, but headers would be nice.
 licenses += "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")
 organizationName         := "Typelevel"
-startYear                := Some(java.time.YearMonth.now().getYear())
+startYear                := Some(2022)
 
 libraryDependencies ++= List(
   "org.scalameta"  % "semanticdb-scalac" % "4.6.0" cross CrossVersion.full,


### PR DESCRIPTION
Ross's advice is to keep this date fixed. I don't much care so long as we can keep CI green :)

Further reading:
- https://github.com/http4s/http4s/pull/5525