### PR TITLE
Updated Scalameta API Call

### DIFF
--- a/project/src/main/scala/org/typelevel/idna4s/build/DerivedJoiningTypeCodeGen.scala
+++ b/project/src/main/scala/org/typelevel/idna4s/build/DerivedJoiningTypeCodeGen.scala
@@ -125,7 +125,7 @@ import scala.collection.immutable.IntMap
 private[uts46] trait ${Type.Name(GeneratedTypeName)} extends ${Init(
         Type.Name(BaseTypeName),
         scala.meta.Name(""),
-        Nil)} {
+        Seq.empty)} {
 ..${joiningTypeMapDef(value)}
 }
 """

--- a/project/src/main/scala/org/typelevel/idna4s/build/UnicodeDataCodeGen.scala
+++ b/project/src/main/scala/org/typelevel/idna4s/build/UnicodeDataCodeGen.scala
@@ -80,7 +80,7 @@ import scala.collection.immutable.IntMap
 private[uts46] trait ${Type.Name(GeneratedTypeName)} extends ${Init(
         Type.Name(BaseTypeName),
         scala.meta.Name(""),
-        Nil)} {
+        Seq.empty)} {
   override final protected lazy val combiningMarkCodePoints: BitSet = $combiningMarkCodePointsRHS
 
   ..${bidirectionalCategoryDefs(unicodeData)}


### PR DESCRIPTION
The overload of `Init.apply` we were using was deprecated.